### PR TITLE
Implemented Object.equals() in Vector classes

### DIFF
--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -235,4 +235,12 @@ public class Vector2d implements Serializable, Externalizable {
         return this;
     }
 
+    public boolean equals(Object o){
+	Vector2d vector = (Vector2d) o;
+	boolean ret = true;
+	ret = ret && vector.x == this.x;
+	ret = ret && vector.y == this.y;
+	return ret;
+    }
+
 }

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -235,12 +235,30 @@ public class Vector2d implements Serializable, Externalizable {
         return this;
     }
 
-    public boolean equals(Object o){
-	Vector2d vector = (Vector2d) o;
-	boolean ret = true;
-	ret = ret && vector.x == this.x;
-	ret = ret && vector.y == this.y;
-	return ret;
-    }
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		long temp;
+		temp = Double.doubleToLongBits(x);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(y);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		return result;
+	}
+
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Vector2d other = (Vector2d) obj;
+		if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+			return false;
+		if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+			return false;
+		return true;
+	}
 
 }

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -174,4 +174,11 @@ public class Vector2f implements Serializable, Externalizable {
         return this;
     }
 
+    public boolean equals(Object o){
+	Vector2f vector = (Vector2f) o;
+	boolean ret = true;
+	ret = ret && vector.x == this.x;
+	ret = ret && vector.y == this.y;
+	return ret;
+    }
 }

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -174,11 +174,26 @@ public class Vector2f implements Serializable, Externalizable {
         return this;
     }
 
-    public boolean equals(Object o){
-	Vector2f vector = (Vector2f) o;
-	boolean ret = true;
-	ret = ret && vector.x == this.x;
-	ret = ret && vector.y == this.y;
-	return ret;
-    }
+    public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Float.floatToIntBits(x);
+		result = prime * result + Float.floatToIntBits(y);
+		return result;
+	}
+
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Vector2f other = (Vector2f) obj;
+		if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+			return false;
+		if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+			return false;
+		return true;
+	}
 }

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -462,13 +462,34 @@ public class Vector3d implements Serializable, Externalizable {
         return this;
     }
 
-    public boolean equals(Object o){
-	Vector3d vector = (Vector3d) o;
-	boolean ret = true;
-	ret = ret && vector.x == this.x;
-	ret = ret && vector.y == this.y;
-	ret = ret && vector.z == this.z;
-	return ret;
-    }
+    public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		long temp;
+		temp = Double.doubleToLongBits(x);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(y);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(z);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		return result;
+	}
+
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Vector3d other = (Vector3d) obj;
+		if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+			return false;
+		if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+			return false;
+		if (Double.doubleToLongBits(z) != Double.doubleToLongBits(other.z))
+			return false;
+		return true;
+	}
 
 }

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -462,4 +462,13 @@ public class Vector3d implements Serializable, Externalizable {
         return this;
     }
 
+    public boolean equals(Object o){
+	Vector3d vector = (Vector3d) o;
+	boolean ret = true;
+	ret = ret && vector.x == this.x;
+	ret = ret && vector.y == this.y;
+	ret = ret && vector.z == this.z;
+	return ret;
+    }
+
 }

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -535,4 +535,13 @@ public class Vector3f implements Serializable, Externalizable {
         return this;
     }
 
+    public boolean equals(Object o){
+	Vector3f vector = (Vector3f) o;
+	boolean ret = true;
+	ret = ret && vector.x == this.x;
+	ret = ret && vector.y == this.y;
+	ret = ret && vector.z == this.z;
+	return ret;
+    }
+
 }

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -535,13 +535,30 @@ public class Vector3f implements Serializable, Externalizable {
         return this;
     }
 
-    public boolean equals(Object o){
-	Vector3f vector = (Vector3f) o;
-	boolean ret = true;
-	ret = ret && vector.x == this.x;
-	ret = ret && vector.y == this.y;
-	ret = ret && vector.z == this.z;
-	return ret;
-    }
+    public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Float.floatToIntBits(x);
+		result = prime * result + Float.floatToIntBits(y);
+		result = prime * result + Float.floatToIntBits(z);
+		return result;
+	}
+
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Vector3f other = (Vector3f) obj;
+		if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+			return false;
+		if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+			return false;
+		if (Float.floatToIntBits(z) != Float.floatToIntBits(other.z))
+			return false;
+		return true;
+	}
 
 }

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -449,4 +449,14 @@ public class Vector4d implements Serializable, Externalizable {
         z = in.readDouble();
     }
 
+    public boolean equals(Object o){
+	Vector4d vector = (Vector4d) o;
+	boolean ret = true;
+	ret = ret && vector.x == this.x;
+	ret = ret && vector.y == this.y;
+	ret = ret && vector.z == this.z;
+	ret = ret && vector.w == this.w;
+	return ret;
+    }
+
 }

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -460,3 +460,5 @@ public class Vector4d implements Serializable, Externalizable {
     }
 
 }
+
+

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -449,15 +449,39 @@ public class Vector4d implements Serializable, Externalizable {
         z = in.readDouble();
     }
 
-    public boolean equals(Object o){
-	Vector4d vector = (Vector4d) o;
-	boolean ret = true;
-	ret = ret && vector.x == this.x;
-	ret = ret && vector.y == this.y;
-	ret = ret && vector.z == this.z;
-	ret = ret && vector.w == this.w;
-	return ret;
-    }
+    public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		long temp;
+		temp = Double.doubleToLongBits(w);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(x);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(y);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		temp = Double.doubleToLongBits(z);
+		result = prime * result + (int) (temp ^ (temp >>> 32));
+		return result;
+	}
+
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Vector4d other = (Vector4d) obj;
+		if (Double.doubleToLongBits(w) != Double.doubleToLongBits(other.w))
+			return false;
+		if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
+			return false;
+		if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
+			return false;
+		if (Double.doubleToLongBits(z) != Double.doubleToLongBits(other.z))
+			return false;
+		return true;
+	}
 
 }
 

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -515,14 +515,33 @@ public class Vector4f implements Serializable, Externalizable {
         return this;
     }
 
-    public boolean equals(Object o){
-	Vector4f vector = (Vector4f) o;
-	boolean ret = true;
-	ret = ret && vector.x == this.x;
-	ret = ret && vector.y == this.y;
-	ret = ret && vector.z == this.z;
-	ret = ret && vector.w == this.w;
-	return ret;
-    }
+    public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Float.floatToIntBits(w);
+		result = prime * result + Float.floatToIntBits(x);
+		result = prime * result + Float.floatToIntBits(y);
+		result = prime * result + Float.floatToIntBits(z);
+		return result;
+	}
+
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Vector4f other = (Vector4f) obj;
+		if (Float.floatToIntBits(w) != Float.floatToIntBits(other.w))
+			return false;
+		if (Float.floatToIntBits(x) != Float.floatToIntBits(other.x))
+			return false;
+		if (Float.floatToIntBits(y) != Float.floatToIntBits(other.y))
+			return false;
+		if (Float.floatToIntBits(z) != Float.floatToIntBits(other.z))
+			return false;
+		return true;
+	}
 }
 

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -524,5 +524,5 @@ public class Vector4f implements Serializable, Externalizable {
 	ret = ret && vector.w == this.w;
 	return ret;
     }
-
 }
+

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -515,4 +515,14 @@ public class Vector4f implements Serializable, Externalizable {
         return this;
     }
 
+    public boolean equals(Object o){
+	Vector4f vector = (Vector4f) o;
+	boolean ret = true;
+	ret = ret && vector.x == this.x;
+	ret = ret && vector.y == this.y;
+	ret = ret && vector.z == this.z;
+	ret = ret && vector.w == this.w;
+	return ret;
+    }
+
 }


### PR DESCRIPTION
Added equals function in Vector classes as a convenience. The equals() function of an object is commonly used in the contains() function of the standard container classes  (e.g. ArrayList, List).