### PR TITLE
Added formatting options to most classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.classpath
 /.project
 /bin/
+/test/

--- a/src/org/joml/AngleAxis4f.java
+++ b/src/org/joml/AngleAxis4f.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 /**
  * Represents a 3D rotation of a given degree about an axis represented as an
@@ -185,7 +187,12 @@ public class AngleAxis4f implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ", " + z + " <| " + angle + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ", " + formatter.format(z) + " <| " + formatter.format(angle) + ")";
     }
 
 }

--- a/src/org/joml/Matrix4d.java
+++ b/src/org/joml/Matrix4d.java
@@ -708,7 +708,7 @@ public class Matrix4d implements Serializable, Externalizable {
         return formatter.format(m00) + ", " + formatter.format(m10) + ", " + formatter.format(m20) + ", " + formatter.format(m30) + ",\n"
              + formatter.format(m01) + ", " + formatter.format(m11) + ", " + formatter.format(m21) + ", " + formatter.format(m31) + ",\n"
              + formatter.format(m02) + ", " + formatter.format(m12) + ", " + formatter.format(m22) + ", " + formatter.format(m32) + ",\n"
-             + formatter.format(m03) + ", " + formatter.format(m13) + ", " + formatter.format(m23) + ", " + formatter.format(m33);
+             + formatter.format(m03) + ", " + formatter.format(m13) + ", " + formatter.format(m23) + ", " + formatter.format(m33) + ",\n";
     }
 
     /**

--- a/src/org/joml/Matrix4f.java
+++ b/src/org/joml/Matrix4f.java
@@ -755,7 +755,7 @@ public class Matrix4f implements Serializable, Externalizable {
         return formatter.format(m00) + ", " + formatter.format(m10) + ", " + formatter.format(m20) + ", " + formatter.format(m30) + ",\n"
              + formatter.format(m01) + ", " + formatter.format(m11) + ", " + formatter.format(m21) + ", " + formatter.format(m31) + ",\n"
              + formatter.format(m02) + ", " + formatter.format(m12) + ", " + formatter.format(m22) + ", " + formatter.format(m32) + ",\n"
-             + formatter.format(m03) + ", " + formatter.format(m13) + ", " + formatter.format(m23) + ", " + formatter.format(m33);
+             + formatter.format(m03) + ", " + formatter.format(m13) + ", " + formatter.format(m23) + ", " + formatter.format(m33) + ",\n";
     }
 
     /**

--- a/src/org/joml/Quaternion.java
+++ b/src/org/joml/Quaternion.java
@@ -28,6 +28,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.nio.FloatBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 /**
  * Contains the definition and functions for rotations expressed as
@@ -722,7 +724,12 @@ public class Quaternion implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ", " + z + ", " + w + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ", " + formatter.format(z) + ", " + formatter.format(w) + ")";
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/src/org/joml/QuaternionD.java
+++ b/src/org/joml/QuaternionD.java
@@ -28,6 +28,8 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.nio.DoubleBuffer;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 /**
  * Contains the definition and functions for rotations expressed as
@@ -740,7 +742,12 @@ public class QuaternionD implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ", " + z + ", " + w + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ", " + formatter.format(z) + ", " + formatter.format(w) + ")";
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 /**
  * Represents a 2D vector with double-precision.
@@ -410,7 +412,12 @@ public class Vector2d implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ")";
     }
 
 }

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 /**
  * Represents a 2D vector with single-precision.
@@ -299,7 +301,12 @@ public class Vector2f implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ")";
     }
 
 

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 
 /**
@@ -503,7 +505,12 @@ public class Vector3d implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ", " + z + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ", " + formatter.format(z) + ")";
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 
 /**
@@ -507,7 +509,12 @@ public class Vector3f implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ", " + z + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ", " + formatter.format(z) + ")";
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 
 /**
@@ -443,7 +445,12 @@ public class Vector4d implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ", " + z + ", " + w + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ", " + formatter.format(z) + ", " + formatter.format(w) + ")";
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 /**
  * Contains the definition of a Vector comprising 4 floats and associated
@@ -466,7 +468,12 @@ public class Vector4f implements Serializable, Externalizable {
     }
 
     public String toString() {
-        return "(" + x + ", " + y + ", " + z + ", " + w + ")";
+    	DecimalFormat formatter = new DecimalFormat("0.000E0");
+    	return toString(formatter);
+    }
+    
+    public String toString(NumberFormat formatter) {
+        return "(" + formatter.format(x) + ", " + formatter.format(y) + ", " + formatter.format(z) + ", " + formatter.format(w) + ")";
     }
 
     public void writeExternal(ObjectOutput out) throws IOException {


### PR DESCRIPTION
# Major #
* In all Vector, Quaternion and AngleAxis classes:
  * `toString()` uses a default format of "0.000E0" (scientific notation with 3 decimal places), just like in the Matrix classes
  * `String toString(NumberFormat)` allows the user to specify their own format, just like in the Matrix classes

# Minor #
* `toString()` in the Matrix4 classes prints a newline directly at the end, so that matrices are better distinguishable (the Matrix3 classes already had this)
* Added /test/ folder to .gitignore (so unit tests don't get committed)