### PR TITLE
Added get/set methods to all Vector classes that accept ByteBuffer and Float/DoubleBuffer.

### DIFF
--- a/src/org/joml/AxisAngle4f.java
+++ b/src/org/joml/AxisAngle4f.java
@@ -167,6 +167,7 @@ public class AxisAngle4f implements Externalizable {
      *            the angle in radians
      * @param v    
      *            the rotation axis as a {@link Vector3f}
+     * @return this
      */
     public AxisAngle4f set(float angle, Vector3f v) {
         return set(angle, v.x, v.y, v.z);

--- a/src/org/joml/AxisAngle4f.java
+++ b/src/org/joml/AxisAngle4f.java
@@ -115,6 +115,16 @@ public class AxisAngle4f implements Externalizable {
     }
 
     /**
+     * Create a new {@link AxisAngle4f} with the given values.
+     *
+     * @param angle the angle in radians
+     * @param v     the rotation axis as a {@link Vector3f}
+     */
+    public AxisAngle4f(float angle, Vector3f v) {
+        this(angle, v.x, v.y, v.z);
+    }
+
+    /**
      * Set this {@link AxisAngle4f} to the values of <code>a</code>.
      * 
      * @param a
@@ -148,6 +158,18 @@ public class AxisAngle4f implements Externalizable {
         this.z = z;
         this.angle = (float) ((angle < 0.0 ? 2.0 * Math.PI + angle % (2.0 * Math.PI) : angle) % (2.0 * Math.PI));
         return this;
+    }
+
+    /**
+     * Set this {@link AxisAngle4f} to the given values.
+     *
+     * @param angle
+     *            the angle in radians
+     * @param v    
+     *            the rotation axis as a {@link Vector3f}
+     */
+    public AxisAngle4f set(float angle, Vector3f v) {
+        return set(angle, v.x, v.y, v.z);
     }
 
     /**

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -92,6 +92,68 @@ public class Vector2d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector2d(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     */
+    public Vector2d(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+    }
+
+    /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link DoubleBuffer}
+     * at the current buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector2d(DoubleBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2d} and read this vector from the supplied {@link DoubleBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     */
+    public Vector2d(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+    }
+
+    /**
      * Set the x and y attributes to the supplied values.
      * 
      * @param x

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -101,7 +101,7 @@ public class Vector2d implements Externalizable {
      * the vector is read, you can use {@link #Vector2d(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     * @param buffer values will be read in <tt>x, y</tt> order
      * @see #Vector2d(int, ByteBuffer)
      */
     public Vector2d(ByteBuffer buffer) {
@@ -115,7 +115,7 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
-     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     * @param buffer values will be read in <tt>x, y</tt> order
      */
     public Vector2d(int index, ByteBuffer buffer) {
         x = buffer.getDouble(index);
@@ -132,7 +132,7 @@ public class Vector2d implements Externalizable {
      * the vector is read, you can use {@link #Vector2d(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     * @param buffer values will be read in <tt>x, y</tt> order
      * @see #Vector2d(int, DoubleBuffer)
      */
     public Vector2d(DoubleBuffer buffer) {
@@ -146,7 +146,7 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer
-     * @param buffer values will be read in <tt>x, y</tt> orderthis
+     * @param buffer values will be read in <tt>x, y</tt> order
      */
     public Vector2d(int index, DoubleBuffer buffer) {
         x = buffer.get(index);

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -131,6 +131,75 @@ public class Vector2d implements Externalizable {
         y = v.y;
         return this;
     }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector2d set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2d set(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector2d set(DoubleBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2d set(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        return this;
+    }
+    
     /**
      * Store this vector into the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -94,15 +94,15 @@ public class Vector2d implements Externalizable {
     /**
      * Create a new {@link Vector2d} and read this vector from the supplied {@link ByteBuffer}
      * at the current buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
-     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the vector is read, you can use {@link #Vector2d(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y</tt> orderthis
-     * @see #set(int, ByteBuffer)
+     * @see #Vector2d(int, ByteBuffer)
      */
     public Vector2d(ByteBuffer buffer) {
         this(buffer.position(), buffer);
@@ -111,7 +111,7 @@ public class Vector2d implements Externalizable {
     /**
      * Create a new {@link Vector2d} and read this vector from the supplied {@link ByteBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -125,15 +125,15 @@ public class Vector2d implements Externalizable {
     /**
      * Create a new {@link Vector2d} and read this vector from the supplied {@link DoubleBuffer}
      * at the current buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
-     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the vector is read, you can use {@link #Vector2d(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y</tt> orderthis
-     * @see #set(int, DoubleBuffer)
+     * @see #Vector2d(int, DoubleBuffer)
      */
     public Vector2d(DoubleBuffer buffer) {
         this(buffer.position(), buffer);
@@ -142,7 +142,7 @@ public class Vector2d implements Externalizable {
     /**
      * Create a new {@link Vector2d} and read this vector from the supplied {@link DoubleBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer
@@ -197,9 +197,9 @@ public class Vector2d implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -215,7 +215,7 @@ public class Vector2d implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -231,9 +231,9 @@ public class Vector2d implements Externalizable {
     /**
      * Read this vector from the supplied {@link DoubleBuffer} at the current
      * buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
      * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
@@ -249,7 +249,7 @@ public class Vector2d implements Externalizable {
     /**
      * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer
@@ -265,9 +265,9 @@ public class Vector2d implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -283,7 +283,7 @@ public class Vector2d implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -299,9 +299,9 @@ public class Vector2d implements Externalizable {
     /**
      * Store this vector into the supplied {@link DoubleBuffer} at the current
      * buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
      * the vector is stored, you can use {@link #get(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
@@ -317,7 +317,7 @@ public class Vector2d implements Externalizable {
     /**
      * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -26,6 +26,8 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
@@ -127,6 +129,73 @@ public class Vector2d implements Externalizable {
     public Vector2d set(Vector2f v) {
         x = v.x;
         y = v.y;
+        return this;
+    }
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     * @see #get(int, ByteBuffer)
+     */
+    public Vector2d get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2d get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index,      x);
+        buffer.putDouble(index + 8,  y);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is stored, you can use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     * @see #get(int, DoubleBuffer)
+     */
+    public Vector2d get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2d get(int index, DoubleBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
         return this;
     }
 

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -79,6 +79,68 @@ public class Vector2f implements Externalizable {
         x = v.x;
         y = v.y;
     }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector2f(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y</tt> order
+     */
+    public Vector2f(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+    }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link FloatBuffer}
+     * at the current buffer {@link FloatBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p/>
+     * If you want to specify the offset into the FloatBuffer at which
+     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector2f(FloatBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector2f} and read this vector from the supplied {@link FloatBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer values will be read in <tt>x, y</tt> order
+     */
+    public Vector2f(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+    }
     
     /**
      * Set the x and y attributes to the supplied values.

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -83,15 +83,15 @@ public class Vector2f implements Externalizable {
     /**
      * Create a new {@link Vector2f} and read this vector from the supplied {@link ByteBuffer}
      * at the current buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
-     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the vector is read, you can use {@link #Vector2f(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y</tt> order
-     * @see #set(int, ByteBuffer)
+     * @see #Vector2f(int, ByteBuffer)
      */
     public Vector2f(ByteBuffer buffer) {
         this(buffer.position(), buffer);
@@ -100,7 +100,7 @@ public class Vector2f implements Externalizable {
     /**
      * Create a new {@link Vector2f} and read this vector from the supplied {@link ByteBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -114,15 +114,15 @@ public class Vector2f implements Externalizable {
     /**
      * Create a new {@link Vector2f} and read this vector from the supplied {@link FloatBuffer}
      * at the current buffer {@link FloatBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the FloatBuffer at which
-     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the vector is read, you can use {@link #Vector2f(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y</tt> order
-     * @see #set(int, FloatBuffer)
+     * @see #Vector2f(int, FloatBuffer)
      */
     public Vector2f(FloatBuffer buffer) {
         this(buffer.position(), buffer);
@@ -131,7 +131,7 @@ public class Vector2f implements Externalizable {
     /**
      * Create a new {@link Vector2f} and read this vector from the supplied {@link FloatBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index  the absolute position into the FloatBuffer
@@ -173,9 +173,9 @@ public class Vector2f implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -191,7 +191,7 @@ public class Vector2f implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -207,9 +207,9 @@ public class Vector2f implements Externalizable {
     /**
      * Read this vector from the supplied {@link FloatBuffer} at the current
      * buffer {@link FloatBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the FloatBuffer at which
      * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
      * the absolute position as parameter.
@@ -225,7 +225,7 @@ public class Vector2f implements Externalizable {
     /**
      * Read this vector from the supplied {@link FloatBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index  the absolute position into the FloatBuffer
@@ -241,9 +241,9 @@ public class Vector2f implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -259,7 +259,7 @@ public class Vector2f implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -275,9 +275,9 @@ public class Vector2f implements Externalizable {
     /**
      * Store this vector into the supplied {@link FloatBuffer} at the current
      * buffer {@link FloatBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the FloatBuffer at which
      * the vector is stored, you can use {@link #get(int, FloatBuffer)}, taking
      * the absolute position as parameter.
@@ -293,7 +293,7 @@ public class Vector2f implements Externalizable {
     /**
      * Store this vector into the supplied {@link FloatBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index  the absolute position into the FloatBuffer

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -107,6 +107,74 @@ public class Vector2f implements Externalizable {
         y = v.y;
         return this;
     }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector2f set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2f set(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p/>
+     * If you want to specify the offset into the FloatBuffer at which
+     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector2f set(FloatBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer values will be read in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2f set(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        return this;
+    }
     
     /**
      * Store this vector into the supplied {@link ByteBuffer} at the current

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -26,6 +26,8 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
@@ -77,7 +79,7 @@ public class Vector2f implements Externalizable {
         x = v.x;
         y = v.y;
     }
-
+    
     /**
      * Set the x and y attributes to the supplied values.
      * 
@@ -103,6 +105,74 @@ public class Vector2f implements Externalizable {
     public Vector2f set(Vector2f v) {
         x = v.x;
         y = v.y;
+        return this;
+    }
+    
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     * @see #get(int, ByteBuffer)
+     */
+    public Vector2f get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2f get(int index, ByteBuffer buffer) {
+        buffer.putFloat(index,      x);
+        buffer.putFloat(index + 4,  y);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p/>
+     * If you want to specify the offset into the FloatBuffer at which
+     * the vector is stored, you can use {@link #get(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     * @see #get(int, FloatBuffer)
+     */
+    public Vector2f get(FloatBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @return this
+     */
+    public Vector2f get(int index, FloatBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
         return this;
     }
 

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -147,6 +147,22 @@ public class Vector3d implements Externalizable {
     }
 
     /**
+     * Set the first two components from the given <code>v</code>
+     * and the z component from the given <code>z</code>
+     *
+     * @param v
+     *            the {@link Vector2d} to copy the values from
+     * @param z
+     *            the z value
+     */
+    public Vector3d set(Vector2d v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        return this;
+    }
+
+    /**
      * Set the x, y and z attributes to match the supplied vector.
      * 
      * @param v
@@ -157,6 +173,22 @@ public class Vector3d implements Externalizable {
         x = v.x;
         y = v.y;
         z = v.z;
+        return this;
+    }
+
+    /**
+     * Set the first two components from the given <code>v</code>
+     * and the z component from the given <code>z</code>
+     *
+     * @param v
+     *            the {@link Vector2f} to copy the values from
+     * @param z
+     *            the z value
+     */
+    public Vector3d set(Vector2f v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
         return this;
     }
 

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -133,6 +133,70 @@ public class Vector3d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector3d(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3d(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+    }
+
+    /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link DoubleBuffer}
+     * at the current buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector3d(DoubleBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3d} and read this vector from the supplied {@link DoubleBuffer}
+     * starting at the specified absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3d(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+    }
+
+    /**
      * Set the x, y and z attributes to match the supplied vector.
      * 
      * @param v

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -218,6 +218,7 @@ public class Vector3d implements Externalizable {
      *            the {@link Vector2d} to copy the values from
      * @param z
      *            the z value
+     * @return this
      */
     public Vector3d set(Vector2d v, double z) {
         this.x = v.x;
@@ -248,6 +249,7 @@ public class Vector3d implements Externalizable {
      *            the {@link Vector2f} to copy the values from
      * @param z
      *            the z value
+     * @return this
      */
     public Vector3d set(Vector2f v, double z) {
         this.x = v.x;

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -26,6 +26,8 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
@@ -89,6 +91,21 @@ public class Vector3d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector3d} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>
+     *
+     * @param v
+     *            the {@link Vector2f} to copy the values from
+     * @param z
+     *            the z value
+     */
+    public Vector3d(Vector2f v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+    }
+
+    /**
      * Create a new {@link Vector3d} whose values will be copied from the given vector.
      * 
      * @param v
@@ -98,6 +115,21 @@ public class Vector3d implements Externalizable {
         this.x = v.x;
         this.y = v.y;
         this.z = v.z;
+    }
+
+    /**
+     * Create a new {@link Vector3d} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>
+     *
+     * @param v
+     *            the {@link Vector2d} to copy the values from
+     * @param z
+     *            the z value
+     */
+    public Vector3d(Vector2d v, double z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
     }
 
     /**
@@ -143,6 +175,76 @@ public class Vector3d implements Externalizable {
         this.x = x;
         this.y = y;
         this.z = z;
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return this
+     * @see #get(int, ByteBuffer)
+     */
+    public Vector3d get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3d get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index,      x);
+        buffer.putDouble(index + 8,  y);
+        buffer.putDouble(index + 16,  z);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is stored, you can use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return this
+     * @see #get(int, DoubleBuffer)
+     */
+    public Vector3d get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3d get(int index, DoubleBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
+        buffer.put(index + 2,  z);
         return this;
     }
 

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -135,15 +135,15 @@ public class Vector3d implements Externalizable {
     /**
      * Create a new {@link Vector3d} and read this vector from the supplied {@link ByteBuffer}
      * at the current buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
-     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the vector is read, you can use {@link #Vector3d(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z</tt> order
-     * @see #set(int, ByteBuffer)
+     * @see #Vector3d(int, ByteBuffer)
      */
     public Vector3d(ByteBuffer buffer) {
         this(buffer.position(), buffer);
@@ -152,7 +152,7 @@ public class Vector3d implements Externalizable {
     /**
      * Create a new {@link Vector3d} and read this vector from the supplied {@link ByteBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -167,15 +167,15 @@ public class Vector3d implements Externalizable {
     /**
      * Create a new {@link Vector3d} and read this vector from the supplied {@link DoubleBuffer}
      * at the current buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
-     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the vector is read, you can use {@link #Vector3d(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z</tt> order
-     * @see #set(int, DoubleBuffer)
+     * @see #Vector3d(int, DoubleBuffer)
      */
     public Vector3d(DoubleBuffer buffer) {
         this(buffer.position(), buffer);
@@ -184,7 +184,7 @@ public class Vector3d implements Externalizable {
     /**
      * Create a new {@link Vector3d} and read this vector from the supplied {@link DoubleBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer
@@ -277,9 +277,9 @@ public class Vector3d implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -295,7 +295,7 @@ public class Vector3d implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -312,9 +312,9 @@ public class Vector3d implements Externalizable {
     /**
      * Read this vector from the supplied {@link DoubleBuffer} at the current
      * buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
      * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
@@ -330,7 +330,7 @@ public class Vector3d implements Externalizable {
     /**
      * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer
@@ -347,9 +347,9 @@ public class Vector3d implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -365,7 +365,7 @@ public class Vector3d implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -382,9 +382,9 @@ public class Vector3d implements Externalizable {
     /**
      * Store this vector into the supplied {@link DoubleBuffer} at the current
      * buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
      * the vector is stored, you can use {@link #get(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
@@ -400,7 +400,7 @@ public class Vector3d implements Externalizable {
     /**
      * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -211,6 +211,76 @@ public class Vector3d implements Externalizable {
     }
 
     /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector3d set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3d set(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector3d set(DoubleBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3d set(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        return this;
+    }
+
+    /**
      * Store this vector into the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
      * <p/>

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -154,6 +154,76 @@ public class Vector3f implements Externalizable {
     }
 
     /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector3f set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3f set(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p/>
+     * If you want to specify the offset into the FloatBuffer at which
+     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector3f set(FloatBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @return this
+     */
+    public Vector3f set(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        return this;
+    }
+
+    /**
      * Store this vector into the supplied {@link FloatBuffer} at the current
      * buffer {@link FloatBuffer#position() position}.
      * <p>

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -106,8 +106,8 @@ public class Vector3f implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer} at the current
-     * buffer {@link ByteBuffer#position() position}.
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
      * <p/>
      * This method will not increment the position of the given ByteBuffer.
      * <p/>
@@ -123,8 +123,8 @@ public class Vector3f implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer} starting at the specified
-     * absolute buffer position/index.
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
      * <p/>
      * This method will not increment the position of the given ByteBuffer.
      *
@@ -134,12 +134,12 @@ public class Vector3f implements Externalizable {
     public Vector3f(int index, ByteBuffer buffer) {
         x = buffer.getFloat(index);
         y = buffer.getFloat(index + 4);
-        z = buffer.getFloat(index + 8);;
+        z = buffer.getFloat(index + 8);
     }
 
     /**
-     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer} at the current
-     * buffer {@link FloatBuffer#position() position}.
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer}
+     * at the current buffer {@link FloatBuffer#position() position}.
      * <p/>
      * This method will not increment the position of the given FloatBuffer.
      * <p/>
@@ -155,8 +155,8 @@ public class Vector3f implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer} starting at the specified
-     * absolute buffer position/index.
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer}
+     * starting at the specified absolute buffer position/index.
      * <p/>
      * This method will not increment the position of the given FloatBuffer.
      *
@@ -166,7 +166,7 @@ public class Vector3f implements Externalizable {
     public Vector3f(int index, FloatBuffer buffer) {
         x = buffer.get(index);
         y = buffer.get(index + 1);
-        z = buffer.get(index + 2);;
+        z = buffer.get(index + 2);
     }
 
     /**

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -191,6 +191,7 @@ public class Vector3f implements Externalizable {
      *            the {@link Vector2f} to copy the values from
      * @param z
      *            the z value
+     * @return this
      */
     public Vector3f set(Vector2f v, float z) {
         this.x = v.x;

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -120,6 +120,22 @@ public class Vector3f implements Externalizable {
     }
 
     /**
+     * Set the first two components from the given <code>v</code>
+     * and the z component from the given <code>z</code>
+     *
+     * @param v
+     *            the {@link Vector2f} to copy the values from
+     * @param z
+     *            the z value
+     */
+    public Vector3f set(Vector2f v, float z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        return this;
+    }
+
+    /**
      * Set the x, y and z attributes to the supplied float values.
      * 
      * @param x

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -108,15 +108,15 @@ public class Vector3f implements Externalizable {
     /**
      * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer}
      * at the current buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
-     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the vector is read, you can use {@link #Vector3f(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z</tt> order
-     * @see #set(int, ByteBuffer)
+     * @see #Vector3f(int, ByteBuffer)
      */
     public Vector3f(ByteBuffer buffer) {
         this(buffer.position(), buffer);
@@ -125,7 +125,7 @@ public class Vector3f implements Externalizable {
     /**
      * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -140,15 +140,15 @@ public class Vector3f implements Externalizable {
     /**
      * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer}
      * at the current buffer {@link FloatBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the FloatBuffer at which
-     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the vector is read, you can use {@link #Vector3f(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z</tt> order
-     * @see #set(int, FloatBuffer)
+     * @see #Vector3f(int, FloatBuffer)
      */
     public Vector3f(FloatBuffer buffer) {
         this(buffer.position(), buffer);
@@ -157,7 +157,7 @@ public class Vector3f implements Externalizable {
     /**
      * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index  the absolute position into the FloatBuffer
@@ -220,9 +220,9 @@ public class Vector3f implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -238,7 +238,7 @@ public class Vector3f implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -255,9 +255,9 @@ public class Vector3f implements Externalizable {
     /**
      * Read this vector from the supplied {@link FloatBuffer} at the current
      * buffer {@link FloatBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the FloatBuffer at which
      * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
      * the absolute position as parameter.
@@ -273,7 +273,7 @@ public class Vector3f implements Externalizable {
     /**
      * Read this vector from the supplied {@link FloatBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index  the absolute position into the FloatBuffer

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -91,6 +91,21 @@ public class Vector3f implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector3f} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>
+     * 
+     * @param v
+     *            the {@link Vector2f} to copy the values from
+     * @param z
+     *            the z value
+     */
+    public Vector3f(Vector2f v, float z) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+    }
+
+    /**
      * Set the x, y and z attributes to match the supplied vector.
      * 
      * @param v

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -106,6 +106,70 @@ public class Vector3f implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector3f(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3f(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);;
+    }
+
+    /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p/>
+     * If you want to specify the offset into the FloatBuffer at which
+     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector3f(FloatBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector3f} and read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer values will be read in <tt>x, y, z</tt> order
+     */
+    public Vector3f(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);;
+    }
+
+    /**
      * Set the x, y and z attributes to match the supplied vector.
      * 
      * @param v

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -181,15 +181,15 @@ public class Vector4d implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
      * at the current buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
-     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the vector is read, you can use {@link #Vector4d(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z, w</tt> order
-     * @see #set(int, ByteBuffer)
+     * @see #Vector4d(int, ByteBuffer)
      */
     public Vector4d(ByteBuffer buffer) {
         this(buffer.position(), buffer);
@@ -198,7 +198,7 @@ public class Vector4d implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -214,15 +214,15 @@ public class Vector4d implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer}
      * at the current buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
-     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the vector is read, you can use {@link #Vector4d(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z, w</tt> order
-     * @see #set(int, DoubleBuffer)
+     * @see #Vector4d(int, DoubleBuffer)
      */
     public Vector4d(DoubleBuffer buffer) {
         this(buffer.position(), buffer);
@@ -231,7 +231,7 @@ public class Vector4d implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer
@@ -369,9 +369,9 @@ public class Vector4d implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -387,7 +387,7 @@ public class Vector4d implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -405,9 +405,9 @@ public class Vector4d implements Externalizable {
     /**
      * Read this vector from the supplied {@link DoubleBuffer} at the current
      * buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
      * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
@@ -423,7 +423,7 @@ public class Vector4d implements Externalizable {
     /**
      * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer
@@ -441,9 +441,9 @@ public class Vector4d implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -459,7 +459,7 @@ public class Vector4d implements Externalizable {
     /**
      * Store this vector into the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -477,9 +477,9 @@ public class Vector4d implements Externalizable {
     /**
      * Store this vector into the supplied {@link DoubleBuffer} at the current
      * buffer {@link DoubleBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the DoubleBuffer at which
      * the vector is stored, you can use {@link #get(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
@@ -495,7 +495,7 @@ public class Vector4d implements Externalizable {
     /**
      * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index  the absolute position into the DoubleBuffer

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -320,6 +320,7 @@ public class Vector4d implements Externalizable {
      *            the z value
      * @param w
      *            the w value
+     * @return this
      */
     public Vector4d set(Vector2d v, double z, double w) {
         this.x = v.x;
@@ -336,6 +337,7 @@ public class Vector4d implements Externalizable {
      * @param v the {@link Vector2f}
      * @param z the z value
      * @param w the w value
+     * @return this
      */
     public Vector4d set(Vector2f v, double z, double w) {
         this.x = v.x;

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -26,6 +26,8 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
@@ -93,6 +95,24 @@ public class Vector4d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector4d} with the first three components from the
+     * given <code>v</code> and the given <code>z</code> and <code>w</code>.
+     *
+     * @param v
+     *            the {@link Vector2d}
+     * @param z
+     *            the z value
+     * @param w
+     *            the w value
+     */
+    public Vector4d(Vector2d v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
      * Create a new {@link Vector4d} with the same values as <code>v</code>.
      * 
      * @param v
@@ -118,6 +138,24 @@ public class Vector4d implements Externalizable {
         this.x = v.x;
         this.y = v.y;
         this.z = v.z;
+        this.w = w;
+    }
+
+    /**
+     * Create a new {@link Vector4d} with the first three components from the
+     * given <code>v</code> and the given <code>z</code> and <code>w</code>.
+     *
+     * @param v
+     *            the {@link Vector2f}
+     * @param z
+     *            the z value
+     * @param w
+     *            the w value
+     */
+    public Vector4d(Vector2f v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
         this.w = w;
     }
 
@@ -224,6 +262,78 @@ public class Vector4d implements Externalizable {
         this.y = y;
         this.z = z;
         this.w = w;
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #get(int, ByteBuffer)
+     */
+    public Vector4d get(ByteBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4d get(int index, ByteBuffer buffer) {
+        buffer.putDouble(index,      x);
+        buffer.putDouble(index + 8,  y);
+        buffer.putDouble(index + 16,  z);
+        buffer.putDouble(index + 24,  w);
+        return this;
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is stored, you can use {@link #get(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #get(int, DoubleBuffer)
+     */
+    public Vector4d get(DoubleBuffer buffer) {
+        return get(buffer.position(), buffer);
+    }
+
+    /**
+     * Store this vector into the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer will receive the values of this vector in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4d get(int index, DoubleBuffer buffer) {
+        buffer.put(index,      x);
+        buffer.put(index + 1,  y);
+        buffer.put(index + 2,  z);
+        buffer.put(index + 3,  w);
         return this;
     }
 

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -301,6 +301,78 @@ public class Vector4d implements Externalizable {
     }
 
     /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector4d set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4d set(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+        w = buffer.getDouble(index + 24);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector4d set(DoubleBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4d set(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);
+        return this;
+    }
+
+    /**
      * Store this vector into the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
      * <p/>

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -179,8 +179,8 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} at the current
-     * buffer {@link ByteBuffer#position() position}.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
      * <p/>
      * This method will not increment the position of the given ByteBuffer.
      * <p/>
@@ -196,8 +196,8 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} starting at the specified
-     * absolute buffer position/index.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
      * <p/>
      * This method will not increment the position of the given ByteBuffer.
      *
@@ -208,12 +208,12 @@ public class Vector4d implements Externalizable {
         x = buffer.getDouble(index);
         y = buffer.getDouble(index + 8);
         z = buffer.getDouble(index + 16);
-        w = buffer.getDouble(index + 24);;
+        w = buffer.getDouble(index + 24);
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer} at the current
-     * buffer {@link DoubleBuffer#position() position}.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer}
+     * at the current buffer {@link DoubleBuffer#position() position}.
      * <p/>
      * This method will not increment the position of the given DoubleBuffer.
      * <p/>
@@ -229,8 +229,8 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer} starting at the specified
-     * absolute buffer position/index.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer}
+     * starting at the specified absolute buffer position/index.
      * <p/>
      * This method will not increment the position of the given DoubleBuffer.
      *
@@ -241,7 +241,7 @@ public class Vector4d implements Externalizable {
         x = buffer.get(index);
         y = buffer.get(index + 1);
         z = buffer.get(index + 2);
-        w = buffer.get(index + 3);;
+        w = buffer.get(index + 3);
     }
 
     /**

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -95,7 +95,7 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4d} with the first three components from the
+     * Create a new {@link Vector4d} with the first two components from the
      * given <code>v</code> and the given <code>z</code> and <code>w</code>.
      *
      * @param v
@@ -142,7 +142,7 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4d} with the first three components from the
+     * Create a new {@link Vector4d} with the first two components from the
      * given <code>v</code> and the given <code>z</code> and <code>w</code>.
      *
      * @param v
@@ -240,6 +240,41 @@ public class Vector4d implements Externalizable {
         this.x = v.x;
         this.y = v.y;
         this.z = v.z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Set the first two components from the given <code>v</code>
+     * and the last two components from the given <code>z</code> and <code>w</code>.
+     *
+     * @param v
+     *            the {@link Vector2d}
+     * @param z
+     *            the z value
+     * @param w
+     *            the w value
+     */
+    public Vector4d set(Vector2d v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+        return this;
+    }
+    
+    /**
+     * Set the first two components from the given <code>v</code>
+     * and the last two components from the given <code>z</code> and <code>w</code>.
+     *
+     * @param v the {@link Vector2f}
+     * @param z the z value
+     * @param w the w value
+     */
+    public Vector4d set(Vector2f v, double z, double w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
         this.w = w;
         return this;
     }

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -179,6 +179,72 @@ public class Vector4d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector4d(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4d(int index, ByteBuffer buffer) {
+        x = buffer.getDouble(index);
+        y = buffer.getDouble(index + 8);
+        z = buffer.getDouble(index + 16);
+        w = buffer.getDouble(index + 24);;
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer} at the current
+     * buffer {@link DoubleBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     * <p/>
+     * If you want to specify the offset into the DoubleBuffer at which
+     * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @see #set(int, DoubleBuffer)
+     */
+    public Vector4d(DoubleBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link DoubleBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given DoubleBuffer.
+     *
+     * @param index  the absolute position into the DoubleBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4d(int index, DoubleBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);;
+    }
+
+    /**
      * Set this {@link Vector4d} to the values of the given <code>v</code>.
      * 
      * @param v

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -134,15 +134,15 @@ public class Vector4f implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
      * at the current buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
-     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the vector is read, you can use {@link #Vector4f(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z, w</tt> order
-     * @see #set(int, ByteBuffer)
+     * @see #Vector4f(int, ByteBuffer)
      */
     public Vector4f(ByteBuffer buffer) {
         this(buffer.position(), buffer);
@@ -151,7 +151,7 @@ public class Vector4f implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -167,15 +167,15 @@ public class Vector4f implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer}
      * at the current buffer {@link FloatBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the FloatBuffer at which
-     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the vector is read, you can use {@link #Vector4f(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
      * @param buffer values will be read in <tt>x, y, z, w</tt> order
-     * @see #set(int, FloatBuffer)
+     * @see #Vector4f(int, FloatBuffer)
      */
     public Vector4f(FloatBuffer buffer) {
         this(buffer.position(), buffer);
@@ -184,7 +184,7 @@ public class Vector4f implements Externalizable {
     /**
      * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer}
      * starting at the specified absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index  the absolute position into the FloatBuffer
@@ -273,9 +273,9 @@ public class Vector4f implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} at the current
      * buffer {@link ByteBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the ByteBuffer at which
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
@@ -291,7 +291,7 @@ public class Vector4f implements Externalizable {
     /**
      * Read this vector from the supplied {@link ByteBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index  the absolute position into the ByteBuffer
@@ -309,9 +309,9 @@ public class Vector4f implements Externalizable {
     /**
      * Read this vector from the supplied {@link FloatBuffer} at the current
      * buffer {@link FloatBuffer#position() position}.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
-     * <p/>
+     * <p>
      * If you want to specify the offset into the FloatBuffer at which
      * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
      * the absolute position as parameter.
@@ -327,7 +327,7 @@ public class Vector4f implements Externalizable {
     /**
      * Read this vector from the supplied {@link FloatBuffer} starting at the specified
      * absolute buffer position/index.
-     * <p/>
+     * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index  the absolute position into the FloatBuffer

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -132,6 +132,72 @@ public class Vector4f implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector4f(ByteBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4f(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);
+        w = buffer.getFloat(index + 12);;
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p/>
+     * If you want to specify the offset into the FloatBuffer at which
+     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector4f(FloatBuffer buffer) {
+        this(buffer.position(), buffer);
+    }
+
+    /**
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     */
+    public Vector4f(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);;
+    }
+
+    /**
      * Set this {@link Vector4f} to the values of the given <code>v</code>.
      * 
      * @param v

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -205,6 +205,78 @@ public class Vector4f implements Externalizable {
     }
 
     /**
+     * Read this vector from the supplied {@link ByteBuffer} at the current
+     * buffer {@link ByteBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     * <p/>
+     * If you want to specify the offset into the ByteBuffer at which
+     * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, ByteBuffer)
+     */
+    public Vector4f set(ByteBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link ByteBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given ByteBuffer.
+     *
+     * @param index  the absolute position into the ByteBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4f set(int index, ByteBuffer buffer) {
+        x = buffer.getFloat(index);
+        y = buffer.getFloat(index + 4);
+        z = buffer.getFloat(index + 8);
+        w = buffer.getFloat(index + 12);
+        return this;
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} at the current
+     * buffer {@link FloatBuffer#position() position}.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     * <p/>
+     * If you want to specify the offset into the FloatBuffer at which
+     * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
+     * the absolute position as parameter.
+     *
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     * @see #set(int, FloatBuffer)
+     */
+    public Vector4f set(FloatBuffer buffer) {
+        return set(buffer.position(), buffer);
+    }
+
+    /**
+     * Read this vector from the supplied {@link FloatBuffer} starting at the specified
+     * absolute buffer position/index.
+     * <p/>
+     * This method will not increment the position of the given FloatBuffer.
+     *
+     * @param index  the absolute position into the FloatBuffer
+     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @return this
+     */
+    public Vector4f set(int index, FloatBuffer buffer) {
+        x = buffer.get(index);
+        y = buffer.get(index + 1);
+        z = buffer.get(index + 2);
+        w = buffer.get(index + 3);
+        return this;
+    }
+
+    /**
      * Store this vector into the supplied {@link FloatBuffer} at the current
      * buffer {@link FloatBuffer#position() position}.
      * <p>

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -240,6 +240,7 @@ public class Vector4f implements Externalizable {
      *            the z value
      * @param w
      *            the w value
+     * @return this
      */
     public Vector4f set(Vector2f v, float z, float w) {
         this.x = v.x;

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -165,9 +165,8 @@ public class Vector4f implements Externalizable {
     }
 
     /**
-     * Sets the first two components of this to the components of
-     * given <code>v</code> and last two components to the given
-     * <code>z</code>, and <code>w</code>.
+     * Sets the first two components of this to the components of given <code>v</code>
+     * and last two components to the given <code>z</code>, and <code>w</code>.
      *
      * @param v
      *            the {@link Vector2f}

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -132,8 +132,8 @@ public class Vector4f implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} at the current
-     * buffer {@link ByteBuffer#position() position}.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * at the current buffer {@link ByteBuffer#position() position}.
      * <p/>
      * This method will not increment the position of the given ByteBuffer.
      * <p/>
@@ -149,8 +149,8 @@ public class Vector4f implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer} starting at the specified
-     * absolute buffer position/index.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link ByteBuffer}
+     * starting at the specified absolute buffer position/index.
      * <p/>
      * This method will not increment the position of the given ByteBuffer.
      *
@@ -161,12 +161,12 @@ public class Vector4f implements Externalizable {
         x = buffer.getFloat(index);
         y = buffer.getFloat(index + 4);
         z = buffer.getFloat(index + 8);
-        w = buffer.getFloat(index + 12);;
+        w = buffer.getFloat(index + 12);
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer} at the current
-     * buffer {@link FloatBuffer#position() position}.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer}
+     * at the current buffer {@link FloatBuffer#position() position}.
      * <p/>
      * This method will not increment the position of the given FloatBuffer.
      * <p/>
@@ -182,8 +182,8 @@ public class Vector4f implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer} starting at the specified
-     * absolute buffer position/index.
+     * Create a new {@link Vector4f} and read this vector from the supplied {@link FloatBuffer}
+     * starting at the specified absolute buffer position/index.
      * <p/>
      * This method will not increment the position of the given FloatBuffer.
      *
@@ -194,7 +194,7 @@ public class Vector4f implements Externalizable {
         x = buffer.get(index);
         y = buffer.get(index + 1);
         z = buffer.get(index + 2);
-        w = buffer.get(index + 3);;
+        w = buffer.get(index + 3);
     }
 
     /**

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -95,6 +95,24 @@ public class Vector4f implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector4f} with the first two components from the
+     * given <code>v</code> and the given <code>z</code>, and <code>w</code>.
+     * 
+     * @param v
+     *            the {@link Vector2f}
+     * @param z
+     *            the z value
+     * @param w
+     *            the w value
+     */
+    public Vector4f(Vector2f v, float z, float w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
+        this.w = w;
+    }
+
+    /**
      * Create a new {@link Vector4f} with the given component values.
      * 
      * @param x
@@ -142,6 +160,26 @@ public class Vector4f implements Externalizable {
         this.x = v.x;
         this.y = v.y;
         this.z = v.z;
+        this.w = w;
+        return this;
+    }
+
+    /**
+     * Sets the first two components of this to the components of
+     * given <code>v</code> and last two components to the given
+     * <code>z</code>, and <code>w</code>.
+     *
+     * @param v
+     *            the {@link Vector2f}
+     * @param z
+     *            the z value
+     * @param w
+     *            the w value
+     */
+    public Vector4f set(Vector2f v, float z, float w) {
+        this.x = v.x;
+        this.y = v.y;
+        this.z = z;
         this.w = w;
         return this;
     }


### PR DESCRIPTION
All Vector classes now have constructors accepting (ByteBuffer) and (index, ByteBuffer), methods set(ByteBuffer) and set(index, ByteBuffer), and methods get(ByteBuffer) and get(index, ByteBuffer).
All Vector float classes have their respective FloatBuffer versions while Vector double classes have their respective DoubleBuffer versions.