### PR TITLE
Single-value constructor and set method and numerous javadoc improvements

### DIFF
--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -42,11 +42,11 @@ public class Vector2d implements Externalizable {
     private static final long serialVersionUID = 1L;
 
     /**
-     * The x-coordinate of the vector.
+     * The x component of the vector.
      */
     public double x;
     /**
-     * The y-coordinate of the vector.
+     * The y component of the vector.
      */
     public double y;
 
@@ -112,7 +112,7 @@ public class Vector2d implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      * @see #Vector2d(int, ByteBuffer)
      */
     public Vector2d(ByteBuffer buffer) {
@@ -126,9 +126,9 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      */
     public Vector2d(int index, ByteBuffer buffer) {
         x = buffer.getDouble(index);
@@ -146,7 +146,7 @@ public class Vector2d implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      * @see #Vector2d(int, DoubleBuffer)
      */
     public Vector2d(DoubleBuffer buffer) {
@@ -160,9 +160,9 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index
-     *            the absolute position into the DoubleBuffer
+     *          the absolute position into the DoubleBuffer
      * @param buffer
-     *            values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      */
     public Vector2d(int index, DoubleBuffer buffer) {
         x = buffer.get(index);
@@ -231,7 +231,7 @@ public class Vector2d implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *                values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      * @return this
      * @see #set(int, ByteBuffer)
      */
@@ -246,9 +246,9 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d set(int index, ByteBuffer buffer) {
@@ -268,7 +268,7 @@ public class Vector2d implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      * @return this
      * @see #set(int, DoubleBuffer)
      */
@@ -283,9 +283,9 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index 
-     *            the absolute position into the DoubleBuffer
+     *          the absolute position into the DoubleBuffer
      * @param buffer
-     *            values will be read in <tt>x, y</tt> order
+     *          values will be read in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d set(int index, DoubleBuffer buffer) {
@@ -305,7 +305,7 @@ public class Vector2d implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y</tt> order
+     *          will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      * @see #get(int, ByteBuffer)
      */
@@ -320,9 +320,9 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index 
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y</tt> order
+     *          will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d get(int index, ByteBuffer buffer) {
@@ -342,7 +342,7 @@ public class Vector2d implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y</tt> order
+     *          will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      * @see #get(int, DoubleBuffer)
      */
@@ -357,9 +357,9 @@ public class Vector2d implements Externalizable {
      * This method will not increment the position of the given DoubleBuffer.
      *
      * @param index
-     *            the absolute position into the DoubleBuffer
+     *          the absolute position into the DoubleBuffer
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y</tt> order
+     *          will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d get(int index, DoubleBuffer buffer) {
@@ -407,9 +407,9 @@ public class Vector2d implements Externalizable {
      * Subtract <tt>(x, y)</tt> from this vector.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @return this
      */
     public Vector2d sub(double x, double y) {
@@ -422,9 +422,9 @@ public class Vector2d implements Externalizable {
      * Subtract <tt>(x, y)</tt> from this vector and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param dest
      *          will hold the result         
      * @return this
@@ -593,9 +593,9 @@ public class Vector2d implements Externalizable {
      * Add <code>(x, y)</code> to this vector.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @return this
      */
     public Vector2d add(double x, double y) {
@@ -608,9 +608,9 @@ public class Vector2d implements Externalizable {
      * Add <code>(x, y)</code> to this vector and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @param dest
      *          will hold the result
      * @return this

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -57,6 +57,16 @@ public class Vector2d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector2d} and initialize both of its components with the given value.
+     * 
+     * @param d    
+     *          the value of both components
+     */
+    public Vector2d(double d) {
+        this(d, d);
+    }
+
+    /**
      * Create a new {@link Vector2d} and initialize its components to the given values.
      * 
      * @param x
@@ -101,7 +111,8 @@ public class Vector2d implements Externalizable {
      * the vector is read, you can use {@link #Vector2d(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y</tt> order
      * @see #Vector2d(int, ByteBuffer)
      */
     public Vector2d(ByteBuffer buffer) {
@@ -114,8 +125,10 @@ public class Vector2d implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y</tt> order
      */
     public Vector2d(int index, ByteBuffer buffer) {
         x = buffer.getDouble(index);
@@ -132,7 +145,8 @@ public class Vector2d implements Externalizable {
      * the vector is read, you can use {@link #Vector2d(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y</tt> order
      * @see #Vector2d(int, DoubleBuffer)
      */
     public Vector2d(DoubleBuffer buffer) {
@@ -145,8 +159,10 @@ public class Vector2d implements Externalizable {
      * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
-     * @param index  the absolute position into the DoubleBuffer
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param index
+     *            the absolute position into the DoubleBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y</tt> order
      */
     public Vector2d(int index, DoubleBuffer buffer) {
         x = buffer.get(index);
@@ -154,12 +170,22 @@ public class Vector2d implements Externalizable {
     }
 
     /**
+     * Set the x and y attributes to the supplied value.
+     *
+     * @param d
+     *          the value of both components
+     */
+    public Vector2d set(double d) {
+        return set(d, d);
+    }
+
+    /**
      * Set the x and y attributes to the supplied values.
      * 
      * @param x
-     *          the x value to set
+     *          the x value
      * @param y
-     *          the y value to set
+     *          the y value
      * @return this
      */
     public Vector2d set(double x, double y) {
@@ -204,7 +230,8 @@ public class Vector2d implements Externalizable {
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *                values will be read in <tt>x, y</tt> order
      * @return this
      * @see #set(int, ByteBuffer)
      */
@@ -218,8 +245,10 @@ public class Vector2d implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d set(int index, ByteBuffer buffer) {
@@ -238,7 +267,8 @@ public class Vector2d implements Externalizable {
      * the vector is read, you can use {@link #set(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y</tt> order
      * @return this
      * @see #set(int, DoubleBuffer)
      */
@@ -252,8 +282,10 @@ public class Vector2d implements Externalizable {
      * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
-     * @param index  the absolute position into the DoubleBuffer
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param index 
+     *            the absolute position into the DoubleBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d set(int index, DoubleBuffer buffer) {
@@ -272,7 +304,8 @@ public class Vector2d implements Externalizable {
      * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param buffer
+     *            will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      * @see #get(int, ByteBuffer)
      */
@@ -286,8 +319,10 @@ public class Vector2d implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param index 
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d get(int index, ByteBuffer buffer) {
@@ -306,7 +341,8 @@ public class Vector2d implements Externalizable {
      * the vector is stored, you can use {@link #get(int, DoubleBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param buffer
+     *            will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      * @see #get(int, DoubleBuffer)
      */
@@ -320,8 +356,10 @@ public class Vector2d implements Externalizable {
      * <p>
      * This method will not increment the position of the given DoubleBuffer.
      *
-     * @param index  the absolute position into the DoubleBuffer
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param index
+     *            the absolute position into the DoubleBuffer
+     * @param buffer
+     *            will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      */
     public Vector2d get(int index, DoubleBuffer buffer) {

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -170,7 +170,7 @@ public class Vector2d implements Externalizable {
     }
 
     /**
-     * Set the x and y attributes to the supplied value.
+     * Set the x and y components to the supplied value.
      *
      * @param d
      *          the value of both components
@@ -181,7 +181,7 @@ public class Vector2d implements Externalizable {
     }
 
     /**
-     * Set the x and y attributes to the supplied values.
+     * Set the x and y components to the supplied values.
      * 
      * @param x
      *          the x value

--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -174,6 +174,7 @@ public class Vector2d implements Externalizable {
      *
      * @param d
      *          the value of both components
+     * @return this
      */
     public Vector2d set(double d) {
         return set(d, d);

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -42,11 +42,11 @@ public class Vector2f implements Externalizable {
     private static final long serialVersionUID = 1L;
 
     /**
-     * The x-coordinate of the vector.
+     * The x component of the vector.
      */
     public float x;
     /**
-     * The y-coordinate of the vector.
+     * The y component of the vector.
      */
     public float y;
 
@@ -60,7 +60,7 @@ public class Vector2f implements Externalizable {
      * Create a new {@link Vector2f} and initialize both of its components with the given value.
      *
      * @param d
-     *          the value of both components
+     *        the value of both components
      */
     public Vector2f(float d) {
         this(d, d);
@@ -70,9 +70,9 @@ public class Vector2f implements Externalizable {
      * Create a new {@link Vector2f} and initialize its components to the given values.
      * 
      * @param x
-     *          the x value
+     *        the x component
      * @param y
-     *          the y value
+     *        the y component
      */
     public Vector2f(float x, float y) {
         this.x = x;
@@ -83,7 +83,7 @@ public class Vector2f implements Externalizable {
      * Create a new {@link Vector2f} and initialize its components to the one of the given vector.
      * 
      * @param v
-     *          the {@link Vector2f} to copy the values from
+     *        the {@link Vector2f} to copy the values from
      */
     public Vector2f(Vector2f v) {
         x = v.x;
@@ -100,7 +100,8 @@ public class Vector2f implements Externalizable {
      * the vector is read, you can use {@link #Vector2f(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
      * @see #Vector2f(int, ByteBuffer)
      */
     public Vector2f(ByteBuffer buffer) {
@@ -113,7 +114,8 @@ public class Vector2f implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
+     * @param index
+     *        the absolute position into the ByteBuffer
      * @param buffer values will be read in <tt>x, y</tt> order
      */
     public Vector2f(int index, ByteBuffer buffer) {
@@ -131,7 +133,8 @@ public class Vector2f implements Externalizable {
      * the vector is read, you can use {@link #Vector2f(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
      * @see #Vector2f(int, FloatBuffer)
      */
     public Vector2f(FloatBuffer buffer) {
@@ -144,8 +147,10 @@ public class Vector2f implements Externalizable {
      * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
-     * @param index  the absolute position into the FloatBuffer
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param index 
+     *        the absolute position into the FloatBuffer
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
      */
     public Vector2f(int index, FloatBuffer buffer) {
         x = buffer.get(index);
@@ -156,7 +161,7 @@ public class Vector2f implements Externalizable {
      * Set the x and y attributes to the supplied value.
      *
      * @param d
-     *          the value of both components
+     *        the value of both components
      */
     public Vector2f set(float d) {
         return set(d, d);
@@ -166,9 +171,9 @@ public class Vector2f implements Externalizable {
      * Set the x and y attributes to the supplied values.
      * 
      * @param x
-     *          the x value
+     *        the x component
      * @param y
-     *          the y value
+     *        the y component
      * @return this
      */
     public Vector2f set(float x, float y) {
@@ -181,7 +186,7 @@ public class Vector2f implements Externalizable {
      * Set this {@link Vector2f} to the values of v.
      * 
      * @param v
-     *          the vector to copy from
+     *        the vector to copy from
      * @return this
      */
     public Vector2f set(Vector2f v) {
@@ -200,7 +205,8 @@ public class Vector2f implements Externalizable {
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
      * @return this
      * @see #set(int, ByteBuffer)
      */
@@ -214,8 +220,10 @@ public class Vector2f implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param index
+     *        the absolute position into the ByteBuffer
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
      * @return this
      */
     public Vector2f set(int index, ByteBuffer buffer) {
@@ -234,7 +242,8 @@ public class Vector2f implements Externalizable {
      * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
      * @return this
      * @see #set(int, FloatBuffer)
      */
@@ -248,8 +257,10 @@ public class Vector2f implements Externalizable {
      * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
-     * @param index  the absolute position into the FloatBuffer
-     * @param buffer values will be read in <tt>x, y</tt> order
+     * @param index 
+     *        the absolute position into the FloatBuffer
+     * @param buffer
+     *        values will be read in <tt>x, y</tt> order
      * @return this
      */
     public Vector2f set(int index, FloatBuffer buffer) {
@@ -268,7 +279,8 @@ public class Vector2f implements Externalizable {
      * the vector is stored, you can use {@link #get(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      * @see #get(int, ByteBuffer)
      */
@@ -282,8 +294,10 @@ public class Vector2f implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param index
+     *        the absolute position into the ByteBuffer
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      */
     public Vector2f get(int index, ByteBuffer buffer) {
@@ -302,7 +316,8 @@ public class Vector2f implements Externalizable {
      * the vector is stored, you can use {@link #get(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      * @see #get(int, FloatBuffer)
      */
@@ -316,8 +331,10 @@ public class Vector2f implements Externalizable {
      * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
-     * @param index  the absolute position into the FloatBuffer
-     * @param buffer will receive the values of this vector in <tt>x, y</tt> order
+     * @param index
+     *        the absolute position into the FloatBuffer
+     * @param buffer
+     *        will receive the values of this vector in <tt>x, y</tt> order
      * @return this
      */
     public Vector2f get(int index, FloatBuffer buffer) {
@@ -330,9 +347,9 @@ public class Vector2f implements Externalizable {
      * Store one perpendicular vector of <code>v</code> in <code>dest</code>.
      * 
      * @param v
-     *          the vector to build one perpendicular vector of
+     *        the vector to build one perpendicular vector of
      * @param dest
-     *          will hold the result
+     *        will hold the result
      */
     public static void perpendicular(Vector2f v, Vector2f dest) {
         dest.x = v.y;
@@ -352,11 +369,11 @@ public class Vector2f implements Externalizable {
      * Subtract <code>b</code> from <code>a</code> and store the result in <code>dest</code>.
      * 
      * @param a
-     *          the first operand
+     *        the first operand
      * @param b
-     *          the second operand
+     *        the second operand
      * @param dest
-     *          will hold the result of <code>a - b</code>
+     *        will hold the result of <code>a - b</code>
      */
     public static void sub(Vector2f a, Vector2f b, Vector2f dest) {
         dest.x = a.x - b.x;
@@ -367,7 +384,7 @@ public class Vector2f implements Externalizable {
      * Subtract <code>v</code> from this vector.
      * 
      * @param v
-     *          the vector to subtract from this
+     *        the vector to subtract from this
      * @return this
      */
     public Vector2f sub(Vector2f v) {
@@ -380,9 +397,9 @@ public class Vector2f implements Externalizable {
      * Subtract <tt>(x, y)</tt> from this vector.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *        the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *        the y component to subtract
      * @return this
      */
     public Vector2f sub(float x, float y) {
@@ -395,7 +412,7 @@ public class Vector2f implements Externalizable {
      * Return the dot product of this vector and <code>v</code>.
      * 
      * @param v
-     *          the other vector
+     *        the other vector
      * @return the dot product
      */
     public float dot(Vector2f v) {
@@ -406,7 +423,7 @@ public class Vector2f implements Externalizable {
      * Return the angle between this vector and the supplied vector.
      * 
      * @param v
-     *          the other vector
+     *        the other vector
      * @return the angle, in radians
      */
     public float angle(Vector2f v) {
@@ -437,7 +454,7 @@ public class Vector2f implements Externalizable {
      * Return the distance between this and <code>v</code>.
      * 
      * @param v
-     *          the other vector
+     *        the other vector
      * @return the distance
      */
     public float distance(Vector2f v) {
@@ -462,7 +479,7 @@ public class Vector2f implements Externalizable {
      * Normalize this vector and store the result in <code>dest</code>.
      * 
      * @param dest
-     *          will hold the result
+     *        will hold the result
      * @return this
      */
     public Vector2f normalize(Vector2f dest) {
@@ -476,7 +493,7 @@ public class Vector2f implements Externalizable {
      * Add <code>v</code> to this vector.
      * 
      * @param v
-     *          the vector to add
+     *        the vector to add
      * @return this
      */
     public Vector2f add(Vector2f v) {
@@ -489,11 +506,11 @@ public class Vector2f implements Externalizable {
      * Add <code>a</code> to <code>b</code> and store the result in <code>dest</code>.
      * 
      * @param a
-     *          the first addend
+     *        the first addend
      * @param b
-     *          the second addend
+     *        the second addend
      * @param dest
-     *          will hold the result
+     *        will hold the result
      */
     public static void add(Vector2f a, Vector2f b, Vector2f dest) {
         dest.x = a.x + b.x;
@@ -537,7 +554,7 @@ public class Vector2f implements Externalizable {
      * Negate this vector and store the result in <code>dest</code>.
      * 
      * @param dest
-     *          will hold the result
+     *        will hold the result
      * @return this
      */
     public Vector2f negate(Vector2f dest) {
@@ -550,7 +567,7 @@ public class Vector2f implements Externalizable {
      * Multiply the components of this vector by the given scalar.
      * 
      * @param scalar
-     *          the value to multiply this vector's components by
+     *        the value to multiply this vector's components by
      * @return this
      */
     public Vector2f mul(float scalar) {
@@ -563,9 +580,9 @@ public class Vector2f implements Externalizable {
      * Multiply the components of this vector by the given scalar and store the result in <code>dest</code>.
      * 
      * @param scalar
-     *          the value to multiply this vector's components by
+     *        the value to multiply this vector's components by
      * @param dest
-     *          will hold the result
+     *        will hold the result
      * @return this
      */
     public Vector2f mul(float scalar, Vector2f dest) {
@@ -613,7 +630,7 @@ public class Vector2f implements Externalizable {
      * Return a string representation of this vector by formatting the vector components with the given {@link NumberFormat}.
      * 
      * @param formatter
-     *          the {@link NumberFormat} used to format the vector components with
+     *        the {@link NumberFormat} used to format the vector components with
      * @return the string representation
      */
     public String toString(NumberFormat formatter) {

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -158,7 +158,7 @@ public class Vector2f implements Externalizable {
     }
 
     /**
-     * Set the x and y attributes to the supplied value.
+     * Set the x and y components to the supplied value.
      *
      * @param d
      *        the value of both components
@@ -169,7 +169,7 @@ public class Vector2f implements Externalizable {
     }
     
     /**
-     * Set the x and y attributes to the supplied values.
+     * Set the x and y components to the supplied values.
      * 
      * @param x
      *        the x component

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -57,6 +57,16 @@ public class Vector2f implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector2f} and initialize both of its components with the given value.
+     *
+     * @param d
+     *          the value of both components
+     */
+    public Vector2f(float d) {
+        this(d, d);
+    }
+
+    /**
      * Create a new {@link Vector2f} and initialize its components to the given values.
      * 
      * @param x
@@ -141,14 +151,24 @@ public class Vector2f implements Externalizable {
         x = buffer.get(index);
         y = buffer.get(index + 1);
     }
+
+    /**
+     * Set the x and y attributes to the supplied value.
+     *
+     * @param d
+     *          the value of both components
+     */
+    public Vector2f set(float d) {
+        return set(d, d);
+    }
     
     /**
      * Set the x and y attributes to the supplied values.
      * 
      * @param x
-     *          the x value to set
+     *          the x value
      * @param y
-     *          the y value to set
+     *          the y value
      * @return this
      */
     public Vector2f set(float x, float y) {

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -162,6 +162,7 @@ public class Vector2f implements Externalizable {
      *
      * @param d
      *        the value of both components
+     * @return this
      */
     public Vector2f set(float d) {
         return set(d, d);

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -44,15 +44,15 @@ public class Vector3d implements Externalizable {
     private static final long serialVersionUID = 1L;   
 
     /**
-     * The x-coordinate of the vector.
+     * The x component of the vector.
      */
     public double x;
     /**
-     * The y-coordinate of the vector.
+     * The y component of the vector.
      */
     public double y;
     /**
-     * The z-coordinate of the vector.
+     * The z component of the vector.
      */
     public double z;
 
@@ -105,9 +105,9 @@ public class Vector3d implements Externalizable {
      * given <code>v</code> and the given <code>z</code>
      *
      * @param v
-     *            the {@link Vector2f} to copy the values from
+     *          the {@link Vector2f} to copy the values from
      * @param z
-     *            the z value
+     *          the z component
      */
     public Vector3d(Vector2f v, double z) {
         this.x = v.x;
@@ -132,9 +132,9 @@ public class Vector3d implements Externalizable {
      * given <code>v</code> and the given <code>z</code>
      *
      * @param v
-     *            the {@link Vector2d} to copy the values from
+     *          the {@link Vector2d} to copy the values from
      * @param z
-     *            the z value
+     *          the z component
      */
     public Vector3d(Vector2d v, double z) {
         this.x = v.x;
@@ -225,9 +225,9 @@ public class Vector3d implements Externalizable {
      * and the z component from the given <code>z</code>
      *
      * @param v
-     *            the {@link Vector2d} to copy the values from
+     *          the {@link Vector2d} to copy the values from
      * @param z
-     *            the z value
+     *          the z component
      * @return this
      */
     public Vector3d set(Vector2d v, double z) {
@@ -256,9 +256,9 @@ public class Vector3d implements Externalizable {
      * and the z component from the given <code>z</code>
      *
      * @param v
-     *            the {@link Vector2f} to copy the values from
+     *          the {@link Vector2f} to copy the values from
      * @param z
-     *            the z value
+     *          the z component
      * @return this
      */
     public Vector3d set(Vector2f v, double z) {
@@ -282,11 +282,11 @@ public class Vector3d implements Externalizable {
      * Set the x, y and z attributes to the supplied values.
      * 
      * @param x
-     *          the x value
+     *          the x component
      * @param y
-     *          the y value
+     *          the y component
      * @param z
-     *          the z value
+     *          the z component
      * @return this
      */
     public Vector3d set(double x, double y, double z) {
@@ -500,11 +500,11 @@ public class Vector3d implements Externalizable {
      * Subtract <tt>(x, y, z)</tt> from this vector.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @return this
      */
     public Vector3d sub(double x, double y, double z) {
@@ -518,11 +518,11 @@ public class Vector3d implements Externalizable {
      * Subtract <tt>(x, y, z)</tt> from this vector and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @param dest
      *          will hold the result
      * @return this
@@ -614,11 +614,11 @@ public class Vector3d implements Externalizable {
      * Increment the components of this vector by the given values.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @param z
-     *          the z-coordinate to add
+     *          the z component to add
      * @return this
      */
     public Vector3d add(double x, double y, double z) {
@@ -632,11 +632,11 @@ public class Vector3d implements Externalizable {
      * Increment the components of this vector by the given values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @param z
-     *          the z-coordinate to add
+     *          the z component to add
      * @param dest
      *          will hold the result
      * @return this
@@ -1014,11 +1014,11 @@ public class Vector3d implements Externalizable {
      * Multiply the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
      * 
      * @param x
-     *          the x-coordinate to multiply this vector by
+     *          the x component to multiply this vector by
      * @param y
-     *          the y-coordinate to multiply this vector by
+     *          the y component to multiply this vector by
      * @param z
-     *          the z-coordinate to multiply this vector by
+     *          the z component to multiply this vector by
      * @return this
      */
     public Vector3d mul(double x, double y, double z) {
@@ -1032,11 +1032,11 @@ public class Vector3d implements Externalizable {
      * Multiply the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to multiply this vector by
+     *          the x component to multiply this vector by
      * @param y
-     *          the y-coordinate to multiply this vector by
+     *          the y component to multiply this vector by
      * @param z
-     *          the z-coordinate to multiply this vector by
+     *          the z component to multiply this vector by
      * @param dest
      *          will hold the result
      * @return this
@@ -1112,11 +1112,11 @@ public class Vector3d implements Externalizable {
      * Divide the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
      * 
      * @param x
-     *          the x-coordinate to divide this vector by
+     *          the x component to divide this vector by
      * @param y
-     *          the y-coordinate to divide this vector by
+     *          the y component to divide this vector by
      * @param z
-     *          the z-coordinate to divide this vector by
+     *          the z component to divide this vector by
      * @return this
      */
     public Vector3d div(double x, double y, double z) {
@@ -1130,11 +1130,11 @@ public class Vector3d implements Externalizable {
      * Divide the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to divide this vector by
+     *          the x component to divide this vector by
      * @param y
-     *          the y-coordinate to divide this vector by
+     *          the y component to divide this vector by
      * @param z
-     *          the z-coordinate to divide this vector by
+     *          the z component to divide this vector by
      * @param dest
      *          will hold the result
      * @return this
@@ -1226,11 +1226,11 @@ public class Vector3d implements Externalizable {
      * Set this vector to be the cross product of itself and <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *          the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *          the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *          the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return this
      */
     public Vector3d cross(double x, double y, double z) {
@@ -1259,11 +1259,11 @@ public class Vector3d implements Externalizable {
      * Compute the cross product of this vector and <tt>(x, y, z)</tt> and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *          the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *          the z-coordinate of the other vector
+     *          the z component of the other vector
      * @param dest
      *          will hold the result
      * @return this
@@ -1292,11 +1292,11 @@ public class Vector3d implements Externalizable {
      * Return the distance between <code>this</code> vector and <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *            the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *            the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *            the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return the euclidean distance
      */
     public double distance(double x, double y, double z) {
@@ -1321,11 +1321,11 @@ public class Vector3d implements Externalizable {
      * Return the dot product of this vector and the vector <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *          the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *          the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *          the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return the dot product
      */
     public double dot(double x, double y, double z) {
@@ -1474,7 +1474,7 @@ public class Vector3d implements Externalizable {
      * Reflect this vector about the given normal vector.
      * 
      * @param normal
-     *             the vector to reflect about
+     *          the vector to reflect about
      * @return this
      */
     public Vector3d reflect(Vector3d normal) {
@@ -1489,11 +1489,11 @@ public class Vector3d implements Externalizable {
      * Reflect this vector about the given normal vector.
      * 
      * @param x
-     *             the x-coordinate of the normal
+     *          the x component of the normal
      * @param y
-     *             the y-coordinate of the normal
+     *          the y component of the normal
      * @param z
-     *             the z-coordinate of the normal
+     *          the z component of the normal
      * @return this
      */
     public Vector3d reflect(double x, double y, double z) {
@@ -1508,9 +1508,9 @@ public class Vector3d implements Externalizable {
      * Reflect this vector about the given normal vector and store the result in <code>dest</code>.
      * 
      * @param normal
-     *             the vector to reflect about
+     *          the vector to reflect about
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3d reflect(Vector3d normal, Vector3d dest) {
@@ -1525,13 +1525,13 @@ public class Vector3d implements Externalizable {
      * Reflect this vector about the given normal vector and store the result in <code>dest</code>.
      * 
      * @param x
-     *             the x-coordinate of the normal
+     *          the x component of the normal
      * @param y
-     *             the y-coordinate of the normal
+     *          the y component of the normal
      * @param z
-     *             the z-coordinate of the normal
+     *          the z component of the normal
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3d reflect(double x, double y, double z, Vector3d dest) {
@@ -1546,7 +1546,7 @@ public class Vector3d implements Externalizable {
      * Compute the half vector between this and the other vector.
      * 
      * @param other
-     *             the other vector
+     *          the other vector
      * @return this
      */
     public Vector3d half(Vector3d other) {
@@ -1557,11 +1557,11 @@ public class Vector3d implements Externalizable {
      * Compute the half vector between this and the vector <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *             the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *             the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *             the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return this
      */
     public Vector3d half(double x, double y, double z) {
@@ -1572,9 +1572,9 @@ public class Vector3d implements Externalizable {
      * Compute the half vector between this and the other vector and store the result in <code>dest</code>.
      * 
      * @param other
-     *             the other vector
+     *          the other vector
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3d half(Vector3d other, Vector3d dest) {
@@ -1587,13 +1587,13 @@ public class Vector3d implements Externalizable {
      * and store the result in <code>dest</code>.
      * 
      * @param x
-     *             the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *             the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *             the z-coordinate of the other vector
+     *          the z component of the other vector
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3d half(double x, double y, double z, Vector3d dest) {
@@ -1607,11 +1607,11 @@ public class Vector3d implements Externalizable {
      * store the result in <code>dest</code>.
      * 
      * @param v
-     *            the other vector
+     *          the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3d smoothStep(Vector3d v, double t, Vector3d dest) {
@@ -1628,15 +1628,15 @@ public class Vector3d implements Externalizable {
      * <code>dest</code>.
      * 
      * @param t0
-     *            the tangent of <code>this</code> vector
+     *          the tangent of <code>this</code> vector
      * @param v1
-     *            the other vector
+     *          the other vector
      * @param t1
-     *            the tangent of the other vector
+     *          the tangent of the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3d hermite(Vector3d t0, Vector3d v1, Vector3d t1, double t, Vector3d dest) {

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -273,6 +273,7 @@ public class Vector3d implements Externalizable {
      *
      * @param d
      *          the value of all three components
+     * @return this
      */
     public Vector3d set(double d) {
         return set(d, d, d);

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -63,6 +63,16 @@ public class Vector3d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector3d} and initialize all three components with the given value.
+     *
+     * @param d
+     *          the value of all three components
+     */
+    public Vector3d(double d) {
+        this(d, d, d);
+    }
+
+    /**
      * Create a new {@link Vector3d} with the given component values.
      * 
      * @param x
@@ -259,14 +269,24 @@ public class Vector3d implements Externalizable {
     }
 
     /**
-     * Set the x, y and z attributes to the supplied float values.
+     * Set the x, y, and z attributes to the supplied value.
+     *
+     * @param d
+     *          the value of all three components
+     */
+    public Vector3d set(double d) {
+        return set(d, d, d);
+    }
+
+    /**
+     * Set the x, y and z attributes to the supplied values.
      * 
      * @param x
-     *          the new value of x
+     *          the x value
      * @param y
-     *          the new value of y
+     *          the y value
      * @param z
-     *          the new value of z
+     *          the z value
      * @return this
      */
     public Vector3d set(double x, double y, double z) {

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -207,7 +207,7 @@ public class Vector3d implements Externalizable {
     }
 
     /**
-     * Set the x, y and z attributes to match the supplied vector.
+     * Set the x, y and z components to match the supplied vector.
      * 
      * @param v
      *          the vector to set this vector's components from
@@ -238,7 +238,7 @@ public class Vector3d implements Externalizable {
     }
 
     /**
-     * Set the x, y and z attributes to match the supplied vector.
+     * Set the x, y and z components to match the supplied vector.
      * 
      * @param v
      *          the vector to set this vector's components from
@@ -269,7 +269,7 @@ public class Vector3d implements Externalizable {
     }
 
     /**
-     * Set the x, y, and z attributes to the supplied value.
+     * Set the x, y, and z components to the supplied value.
      *
      * @param d
      *          the value of all three components
@@ -280,7 +280,7 @@ public class Vector3d implements Externalizable {
     }
 
     /**
-     * Set the x, y and z attributes to the supplied values.
+     * Set the x, y and z components to the supplied values.
      * 
      * @param x
      *          the x component

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -44,15 +44,15 @@ public class Vector3f implements Externalizable {
     private static final long serialVersionUID = 1L;    
 
     /**
-     * The x-coordinate of the vector.
+     * The x component of the vector.
      */
     public float x;
     /**
-     * The y-coordinate of the vector.
+     * The y component of the vector.
      */
     public float y;
     /**
-     * The z-coordinate of the vector.
+     * The z component of the vector.
      */
     public float z;
 
@@ -92,7 +92,7 @@ public class Vector3f implements Externalizable {
      * Create a new {@link Vector3f} with the same values as <code>v</code>.
      * 
      * @param v
-     *            the {@link Vector3f} to copy the values from
+     *          the {@link Vector3f} to copy the values from
      */
     public Vector3f(Vector3f v) {
         this.x = v.x;
@@ -105,9 +105,9 @@ public class Vector3f implements Externalizable {
      * given <code>v</code> and the given <code>z</code>
      * 
      * @param v
-     *            the {@link Vector2f} to copy the values from
+     *          the {@link Vector2f} to copy the values from
      * @param z
-     *            the z component
+     *          the z component
      */
     public Vector3f(Vector2f v, float z) {
         this.x = v.x;
@@ -198,9 +198,9 @@ public class Vector3f implements Externalizable {
      * and the z component from the given <code>z</code>
      *
      * @param v
-     *            the {@link Vector2f} to copy the values from
+     *          the {@link Vector2f} to copy the values from
      * @param z
-     *            the z component
+     *          the z component
      * @return this
      */
     public Vector3f set(Vector2f v, float z) {
@@ -249,7 +249,7 @@ public class Vector3f implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y, z</tt> order
+     *          values will be read in <tt>x, y, z</tt> order
      * @return this
      * @see #set(int, ByteBuffer)
      */
@@ -264,9 +264,9 @@ public class Vector3f implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            values will be read in <tt>x, y, z</tt> order
+     *          values will be read in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f set(int index, ByteBuffer buffer) {
@@ -287,7 +287,7 @@ public class Vector3f implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y, z</tt> order
+     *          values will be read in <tt>x, y, z</tt> order
      * @return this
      * @see #set(int, FloatBuffer)
      */
@@ -302,9 +302,9 @@ public class Vector3f implements Externalizable {
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index
-     *            the absolute position into the FloatBuffer
+     *          the absolute position into the FloatBuffer
      * @param buffer
-     *            values will be read in <tt>x, y, z</tt> order
+     *          values will be read in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f set(int index, FloatBuffer buffer) {
@@ -327,7 +327,7 @@ public class Vector3f implements Externalizable {
      * @see #get(int, FloatBuffer)
      * 
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z</tt> order
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f get(FloatBuffer buffer) {
@@ -341,9 +341,9 @@ public class Vector3f implements Externalizable {
      * This method will not increment the position of the given FloatBuffer.
      * 
      * @param index
-     *            the absolute position into the FloatBuffer
+     *          the absolute position into the FloatBuffer
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z</tt> order
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f get(int index, FloatBuffer buffer) {
@@ -366,7 +366,7 @@ public class Vector3f implements Externalizable {
      * @see #get(int, ByteBuffer)
      * 
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z</tt> order
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f get(ByteBuffer buffer) {
@@ -380,9 +380,9 @@ public class Vector3f implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      * 
      * @param index
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z</tt> order
+     *          will receive the values of this vector in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f get(int index, ByteBuffer buffer) {
@@ -426,11 +426,11 @@ public class Vector3f implements Externalizable {
      * Decrement the components of this vector by the given values.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @return this
      */
     public Vector3f sub(float x, float y, float z) {
@@ -444,11 +444,11 @@ public class Vector3f implements Externalizable {
      * Decrement the components of this vector by the given values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @param dest
      *          will hold the result
      * @return this
@@ -494,11 +494,11 @@ public class Vector3f implements Externalizable {
      * Increment the components of this vector by the given values.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @param z
-     *          the z-coordinate to add
+     *          the z component to add
      * @return this
      */
     public Vector3f add(float x, float y, float z) {
@@ -512,11 +512,11 @@ public class Vector3f implements Externalizable {
      * Increment the components of this vector by the given values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @param z
-     *          the z-coordinate to add
+     *          the z component to add
      * @param dest
      *          will hold the result
      * @return this
@@ -760,11 +760,11 @@ public class Vector3f implements Externalizable {
      * Multiply the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
      * 
      * @param x
-     *          the x-coordinate to multiply this vector by
+     *          the x component to multiply this vector by
      * @param y
-     *          the y-coordinate to multiply this vector by
+     *          the y component to multiply this vector by
      * @param z
-     *          the z-coordinate to multiply this vector by
+     *          the z component to multiply this vector by
      * @return this
      */
     public Vector3f mul(float x, float y, float z) {
@@ -778,11 +778,11 @@ public class Vector3f implements Externalizable {
      * Multiply the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to multiply this vector by
+     *          the x component to multiply this vector by
      * @param y
-     *          the y-coordinate to multiply this vector by
+     *          the y component to multiply this vector by
      * @param z
-     *          the z-coordinate to multiply this vector by
+     *          the z component to multiply this vector by
      * @param dest
      *          will hold the result
      * @return this
@@ -830,11 +830,11 @@ public class Vector3f implements Externalizable {
      * Divide the components of this Vector3f by the given scalar values and store the result in <code>this</code>.
      * 
      * @param x
-     *          the x-coordinate to divide this vector by
+     *          the x component to divide this vector by
      * @param y
-     *          the y-coordinate to divide this vector by
+     *          the y component to divide this vector by
      * @param z
-     *          the z-coordinate to divide this vector by
+     *          the z component to divide this vector by
      * @return this
      */
     public Vector3f div(float x, float y, float z) {
@@ -848,11 +848,11 @@ public class Vector3f implements Externalizable {
      * Divide the components of this Vector3f by the given scalar values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to divide this vector by
+     *          the x component to divide this vector by
      * @param y
-     *          the y-coordinate to divide this vector by
+     *          the y component to divide this vector by
      * @param z
-     *          the z-coordinate to divide this vector by
+     *          the z component to divide this vector by
      * @param dest
      *          will hold the result
      * @return this
@@ -957,11 +957,11 @@ public class Vector3f implements Externalizable {
      * Set this vector to be the cross product of itself and <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *          the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *          the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *          the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return this
      */
     public Vector3f cross(float x, float y, float z) {
@@ -989,11 +989,11 @@ public class Vector3f implements Externalizable {
      * Compute the cross product of this vector and <tt>(x, y, z)</tt> and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *          the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *          the z-coordinate of the other vector
+     *          the z component of the other vector
      * @param dest
      *          will hold the result
      * @return this
@@ -1022,11 +1022,11 @@ public class Vector3f implements Externalizable {
      * Return the distance between <code>this</code> vector and <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *            the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *            the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *            the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return the euclidean distance
      */
     public float distance(float x, float y, float z) {
@@ -1051,11 +1051,11 @@ public class Vector3f implements Externalizable {
      * Return the dot product of this vector and the vector <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *          the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *          the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *          the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return the dot product
      */
     public float dot(float x, float y, float z) {
@@ -1227,7 +1227,7 @@ public class Vector3f implements Externalizable {
      * Reflect this vector about the given <code>normal</code> vector.
      * 
      * @param normal
-     *             the vector to reflect about
+     *          the vector to reflect about
      * @return this
      */
     public Vector3f reflect(Vector3f normal) {
@@ -1242,11 +1242,11 @@ public class Vector3f implements Externalizable {
      * Reflect this vector about the given normal vector.
      * 
      * @param x
-     *             the x-coordinate of the normal
+     *          the x component of the normal
      * @param y
-     *             the y-coordinate of the normal
+     *          the y component of the normal
      * @param z
-     *             the z-coordinate of the normal
+     *          the z component of the normal
      * @return this
      */
     public Vector3f reflect(float x, float y, float z) {
@@ -1261,9 +1261,9 @@ public class Vector3f implements Externalizable {
      * Reflect this vector about the given <code>normal</code> vector and store the result in <code>dest</code>.
      * 
      * @param normal
-     *             the vector to reflect about
+     *          the vector to reflect about
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3f reflect(Vector3f normal, Vector3f dest) {
@@ -1278,13 +1278,13 @@ public class Vector3f implements Externalizable {
      * Reflect this vector about the given normal vector and store the result in <code>dest</code>.
      * 
      * @param x
-     *             the x-coordinate of the normal
+     *          the x component of the normal
      * @param y
-     *             the y-coordinate of the normal
+     *          the y component of the normal
      * @param z
-     *             the z-coordinate of the normal
+     *          the z component of the normal
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3f reflect(float x, float y, float z, Vector3f dest) {
@@ -1299,7 +1299,7 @@ public class Vector3f implements Externalizable {
      * Compute the half vector between this and the other vector.
      * 
      * @param other
-     *             the other vector
+     *          the other vector
      * @return this
      */
     public Vector3f half(Vector3f other) {
@@ -1310,11 +1310,11 @@ public class Vector3f implements Externalizable {
      * Compute the half vector between this and the vector <tt>(x, y, z)</tt>.
      * 
      * @param x
-     *             the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *             the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *             the z-coordinate of the other vector
+     *          the z component of the other vector
      * @return this
      */
     public Vector3f half(float x, float y, float z) {
@@ -1325,9 +1325,9 @@ public class Vector3f implements Externalizable {
      * Compute the half vector between this and the other vector and store the result in <code>dest</code>.
      * 
      * @param other
-     *             the other vector
+     *          the other vector
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3f half(Vector3f other, Vector3f dest) {
@@ -1340,13 +1340,13 @@ public class Vector3f implements Externalizable {
      * and store the result in <code>dest</code>.
      * 
      * @param x
-     *             the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *             the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *             the z-coordinate of the other vector
+     *          the z component of the other vector
      * @param dest
-     *             will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3f half(float x, float y, float z, Vector3f dest) {
@@ -1360,11 +1360,11 @@ public class Vector3f implements Externalizable {
      * store the result in <code>dest</code>.
      * 
      * @param v
-     *            the other vector
+     *          the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3f smoothStep(Vector3f v, float t, Vector3f dest) {
@@ -1381,15 +1381,15 @@ public class Vector3f implements Externalizable {
      * <code>dest</code>.
      * 
      * @param t0
-     *            the tangent of <code>this</code> vector
+     *          the tangent of <code>this</code> vector
      * @param v1
-     *            the other vector
+     *          the other vector
      * @param t1
-     *            the tangent of the other vector
+     *          the tangent of the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector3f hermite(Vector3f t0, Vector3f v1, Vector3f t1, float t, Vector3f dest) {

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -180,7 +180,7 @@ public class Vector3f implements Externalizable {
     }
 
     /**
-     * Set the x, y and z attributes to match the supplied vector.
+     * Set the x, y and z components to match the supplied vector.
      * 
      * @param v
      *          contains the values of x, y and z to set
@@ -211,7 +211,7 @@ public class Vector3f implements Externalizable {
     }
 
     /**
-     * Set the x, y, and z attributes to the supplied value.
+     * Set the x, y, and z components to the supplied value.
      *
      * @param d
      *          the value of all three components
@@ -222,7 +222,7 @@ public class Vector3f implements Externalizable {
     }
 
     /**
-     * Set the x, y and z attributes to the supplied values.
+     * Set the x, y and z components to the supplied values.
      * 
      * @param x
      *          the x component

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -63,6 +63,16 @@ public class Vector3f implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector3f} and initialize all three components with the given value.
+     *
+     * @param d
+     *          the value of all three components
+     */
+    public Vector3f(float d) {
+        this(d, d, d);
+    }
+
+    /**
      * Create a new {@link Vector4f} with the given component values.
      * 
      * @param x
@@ -97,7 +107,7 @@ public class Vector3f implements Externalizable {
      * @param v
      *            the {@link Vector2f} to copy the values from
      * @param z
-     *            the z value
+     *            the z component
      */
     public Vector3f(Vector2f v, float z) {
         this.x = v.x;
@@ -190,7 +200,7 @@ public class Vector3f implements Externalizable {
      * @param v
      *            the {@link Vector2f} to copy the values from
      * @param z
-     *            the z value
+     *            the z component
      * @return this
      */
     public Vector3f set(Vector2f v, float z) {
@@ -201,14 +211,24 @@ public class Vector3f implements Externalizable {
     }
 
     /**
-     * Set the x, y and z attributes to the supplied float values.
+     * Set the x, y, and z attributes to the supplied value.
+     *
+     * @param d
+     *          the value of all three components
+     */
+    public Vector3f set(float d) {
+        return set(d, d, d);
+    }
+
+    /**
+     * Set the x, y and z attributes to the supplied values.
      * 
      * @param x
-     *          the value of x
+     *          the x component
      * @param y
-     *          the value of y
+     *          the y component 
      * @param z
-     *          the value of z
+     *          the z component
      * @return this
      */
     public Vector3f set(float x, float y, float z) {
@@ -228,7 +248,8 @@ public class Vector3f implements Externalizable {
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y, z</tt> order
      * @return this
      * @see #set(int, ByteBuffer)
      */
@@ -242,8 +263,10 @@ public class Vector3f implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f set(int index, ByteBuffer buffer) {
@@ -263,7 +286,8 @@ public class Vector3f implements Externalizable {
      * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y, z</tt> order
      * @return this
      * @see #set(int, FloatBuffer)
      */
@@ -277,8 +301,10 @@ public class Vector3f implements Externalizable {
      * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
-     * @param index  the absolute position into the FloatBuffer
-     * @param buffer values will be read in <tt>x, y, z</tt> order
+     * @param index
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y, z</tt> order
      * @return this
      */
     public Vector3f set(int index, FloatBuffer buffer) {

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -215,6 +215,7 @@ public class Vector3f implements Externalizable {
      *
      * @param d
      *          the value of all three components
+     * @return this
      */
     public Vector3f set(float d) {
         return set(d, d, d);

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -362,7 +362,7 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Set the x, y, z, and w attributes to the supplied value.
+     * Set the x, y, z, and w components to the supplied value.
      *
      * @param d
      *          the value of all four components
@@ -373,7 +373,7 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Set the x, y, z, and w attributes to the supplied values.
+     * Set the x, y, z, and w components to the supplied values.
      * 
      * @param x
      *          the x component

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -43,19 +43,19 @@ public class Vector4d implements Externalizable {
     private static final long serialVersionUID = 1L;   
 
     /**
-     * The x-coordinate of the vector.
+     * The x component of the vector.
      */
     public double x;
     /**
-     * The y-coordinate of the vector.
+     * The y component of the vector.
      */
     public double y;
     /**
-     * The z-coordinate of the vector.
+     * The z component of the vector.
      */
     public double z;
     /**
-     * The w-coordinate of the vector.
+     * The w component of the vector.
      */
     public double w = 1.0;
 
@@ -69,7 +69,7 @@ public class Vector4d implements Externalizable {
      * Create a new {@link Vector4d} with the same values as <code>v</code>.
      * 
      * @param v
-     *            the {@link Vector4d} to copy the values from
+     *          the {@link Vector4d} to copy the values from
      */
     public Vector4d(Vector4d v) {
         this.x = v.x;
@@ -83,9 +83,9 @@ public class Vector4d implements Externalizable {
      * given <code>v</code> and the given <code>w</code>.
      * 
      * @param v
-     *            the {@link Vector3d}
+     *          the {@link Vector3d}
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4d(Vector3d v, double w) {
         this.x = v.x;
@@ -99,11 +99,11 @@ public class Vector4d implements Externalizable {
      * given <code>v</code> and the given <code>z</code> and <code>w</code>.
      *
      * @param v
-     *            the {@link Vector2d}
+     *          the {@link Vector2d}
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4d(Vector2d v, double z, double w) {
         this.x = v.x;
@@ -116,7 +116,7 @@ public class Vector4d implements Externalizable {
      * Create a new {@link Vector4d} with the same values as <code>v</code>.
      * 
      * @param v
-     *            the {@link Vector4f} to copy the values from
+     *          the {@link Vector4f} to copy the values from
      */
     public Vector4d(Vector4f v) {
         this.x = v.x;
@@ -130,9 +130,9 @@ public class Vector4d implements Externalizable {
      * given <code>v</code> and the w component from the given <code>w</code>.
      * 
      * @param v
-     *            the {@link Vector3f}
+     *          the {@link Vector3f}
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4d(Vector3f v, double w) {
         this.x = v.x;
@@ -146,11 +146,11 @@ public class Vector4d implements Externalizable {
      * given <code>v</code> and the z and w components from the given <code>z</code> and <code>w</code>.
      *
      * @param v
-     *            the {@link Vector2f}
+     *          the {@link Vector2f}
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4d(Vector2f v, double z, double w) {
         this.x = v.x;
@@ -163,7 +163,7 @@ public class Vector4d implements Externalizable {
      * Create a new {@link Vector4d} and initialize all four components with the given value.
      *
      * @param d
-     *            the value of all four components
+     *          the value of all four components
      */
     public Vector4d(double d) {
         this(d, d, d, d);
@@ -173,13 +173,13 @@ public class Vector4d implements Externalizable {
      * Create a new {@link Vector4f} with the given component values.
      * 
      * @param x    
-     *            the x component
+     *          the x component
      * @param y
-     *            the y component
+     *          the y component
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4d(double x, double y, double z, double w) {
         this.x = x;
@@ -199,7 +199,7 @@ public class Vector4d implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      * @see #Vector4d(int, ByteBuffer)
      */
     public Vector4d(ByteBuffer buffer) {
@@ -259,7 +259,7 @@ public class Vector4d implements Externalizable {
      * Set this {@link Vector4d} to the values of the given <code>v</code>.
      * 
      * @param v
-     *            the vector whose values will be copied into this
+     *          the vector whose values will be copied into this
      * @return this
      */
     public Vector4d set(Vector4d v) {
@@ -274,7 +274,7 @@ public class Vector4d implements Externalizable {
      * Set this {@link Vector4d} to the values of the given <code>v</code>.
      * 
      * @param v
-     *            the vector whose values will be copied into this
+     *          the vector whose values will be copied into this
      * @return this
      */
     public Vector4d set(Vector4f v) {
@@ -290,9 +290,9 @@ public class Vector4d implements Externalizable {
      * <code>v</code> and the w component to <code>w</code>.
      * 
      * @param v
-     *            the {@link Vector3d} to copy
+     *          the {@link Vector3d} to copy
      * @param w
-     *            the w component
+     *          the w component
      * @return this
      */
     public Vector4d set(Vector3d v, double w) {
@@ -308,9 +308,9 @@ public class Vector4d implements Externalizable {
      * <code>v</code> and the w component to <code>w</code>.
      * 
      * @param v
-     *            the {@link Vector3f} to copy
+     *          the {@link Vector3f} to copy
      * @param w
-     *            the w component
+     *          the w component
      * @return this
      */
     public Vector4d set(Vector3f v, double w) {
@@ -326,11 +326,11 @@ public class Vector4d implements Externalizable {
      * and the z and w components to the given <code>z</code> and <code>w</code>.
      *
      * @param v
-     *            the {@link Vector2d}
+     *          the {@link Vector2d}
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      * @return this
      */
     public Vector4d set(Vector2d v, double z, double w) {
@@ -346,11 +346,11 @@ public class Vector4d implements Externalizable {
      * and the z and w components to the given <code>z</code> and <code>w</code>.
      *
      * @param v
-     *            the {@link Vector2f}
+     *          the {@link Vector2f}
      * @param z
-     *            the z components
+     *          the z components
      * @param w
-     *            the w components
+     *          the w components
      * @return this
      */
     public Vector4d set(Vector2f v, double z, double w) {
@@ -375,13 +375,13 @@ public class Vector4d implements Externalizable {
      * Set the x, y, z, and w attributes to the supplied values.
      * 
      * @param x
-     *            the x component
+     *          the x component
      * @param y
-     *            the y component
+     *          the y component
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      * @return this
      */
     public Vector4d set(double x, double y, double z, double w) {
@@ -570,13 +570,13 @@ public class Vector4d implements Externalizable {
      * Subtract <tt>(x, y, z, w)</tt> from this.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @param w
-     *          the w-coordinate to subtract
+     *          the w component to subtract
      * @return this
      */
     public Vector4d sub(double x, double y, double z, double w) {
@@ -591,13 +591,13 @@ public class Vector4d implements Externalizable {
      * Subtract <tt>(x, y, z, w)</tt> from this and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @param w
-     *          the w-coordinate to subtract
+     *          the w component to subtract
      * @param dest
      *          will hold the result
      * @return this
@@ -680,13 +680,13 @@ public class Vector4d implements Externalizable {
      * Add <tt>(x, y, z, w)</tt> to this.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @param w
-     *          the w-coordinate to subtract
+     *          the w component to subtract
      * @return this
      */
     public Vector4d add(double x, double y, double z, double w) {
@@ -701,13 +701,13 @@ public class Vector4d implements Externalizable {
      * Add <tt>(x, y, z, w)</tt> to this and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *          the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *          the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *          the z component to subtract
      * @param w
-     *          the w-coordinate to subtract
+     *          the w component to subtract
      * @param dest
      *          will hold the result
      * @return this
@@ -1028,9 +1028,9 @@ public class Vector4d implements Externalizable {
      * Multiply this Vector4d by the given scalar value and store the result in <code>dest</code>.
      * 
      * @param scalar
-     *              the factor to multiply by
+     *          the factor to multiply by
      * @param dest
-     *              will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector4d mul(double scalar, Vector4d dest) {
@@ -1060,9 +1060,9 @@ public class Vector4d implements Externalizable {
      * Divide this Vector4d by the given scalar value and store the result in <code>dest</code>.
      * 
      * @param scalar
-     *              the factor to divide by
+     *          the factor to divide by
      * @param dest
-     *              will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector4d div(double scalar, Vector4d dest) {
@@ -1199,13 +1199,13 @@ public class Vector4d implements Externalizable {
      * Return the distance between <code>this</code> vector and <tt>(x, y, z, w)</tt>.
      * 
      * @param x
-     *            the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *            the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *            the z-coordinate of the other vector
+     *          the z component of the other vector
      * @param w
-     *            the w-coordinate of the other vector
+     *          the w component of the other vector
      * @return the euclidean distance
      */
     public double distance(double x, double y, double z, double w) {
@@ -1220,7 +1220,7 @@ public class Vector4d implements Externalizable {
      * Compute the dot product (inner product) of this vector and <code>v</code>.
      * 
      * @param v
-     *            the other vector
+     *          the other vector
      * @return the dot product
      */
     public double dot(Vector4d v) {
@@ -1231,13 +1231,13 @@ public class Vector4d implements Externalizable {
      * Compute the dot product (inner product) of this vector and <tt>(x, y, z, w)</tt>.
      * 
      * @param x
-     *            the x-coordinate of the other vector
+     *          the x component of the other vector
      * @param y
-     *            the y-coordinate of the other vector
+     *          the y component of the other vector
      * @param z
-     *            the z-coordinate of the other vector
+     *          the z component of the other vector
      * @param w
-     *            the w-coordinate of the other vector
+     *          the w component of the other vector
      * @return the dot product
      */
     public double dot(double x, double y, double z, double w) {
@@ -1396,11 +1396,11 @@ public class Vector4d implements Externalizable {
      * store the result in <code>dest</code>.
      * 
      * @param v
-     *            the other vector
+     *          the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector4d smoothStep(Vector4d v, double t, Vector4d dest) {
@@ -1418,15 +1418,15 @@ public class Vector4d implements Externalizable {
      * <code>dest</code>.
      * 
      * @param t0
-     *            the tangent of <code>this</code> vector
+     *          the tangent of <code>this</code> vector
      * @param v1
-     *            the other vector
+     *          the other vector
      * @param t1
-     *            the tangent of the other vector
+     *          the tangent of the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector4d hermite(Vector4d t0, Vector4d v1, Vector4d t1, double t, Vector4d dest) {

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -85,7 +85,7 @@ public class Vector4d implements Externalizable {
      * @param v
      *            the {@link Vector3d}
      * @param w
-     *            the w value
+     *            the w component
      */
     public Vector4d(Vector3d v, double w) {
         this.x = v.x;
@@ -101,9 +101,9 @@ public class Vector4d implements Externalizable {
      * @param v
      *            the {@link Vector2d}
      * @param z
-     *            the z value
+     *            the z component
      * @param w
-     *            the w value
+     *            the w component
      */
     public Vector4d(Vector2d v, double z, double w) {
         this.x = v.x;
@@ -126,13 +126,13 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4d} with the first three components from the
-     * given <code>v</code> and the given <code>w</code>.
+     * Create a new {@link Vector4d} with the x, y, and z components from the
+     * given <code>v</code> and the w component from the given <code>w</code>.
      * 
      * @param v
      *            the {@link Vector3f}
      * @param w
-     *            the w value
+     *            the w component
      */
     public Vector4d(Vector3f v, double w) {
         this.x = v.x;
@@ -142,15 +142,15 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Create a new {@link Vector4d} with the first two components from the
-     * given <code>v</code> and the given <code>z</code> and <code>w</code>.
+     * Create a new {@link Vector4d} with the x and y components from the
+     * given <code>v</code> and the z and w components from the given <code>z</code> and <code>w</code>.
      *
      * @param v
      *            the {@link Vector2f}
      * @param z
-     *            the z value
+     *            the z component
      * @param w
-     *            the w value
+     *            the w component
      */
     public Vector4d(Vector2f v, double z, double w) {
         this.x = v.x;
@@ -160,16 +160,26 @@ public class Vector4d implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector4d} and initialize all four components with the given value.
+     *
+     * @param d
+     *            the value of all four components
+     */
+    public Vector4d(double d) {
+        this(d, d, d, d);
+    }
+
+    /**
      * Create a new {@link Vector4f} with the given component values.
      * 
-     * @param x
-     *          the value of x
+     * @param x    
+     *            the x component
      * @param y
-     *          the value of y
+     *            the y component
      * @param z
-     *          the value of z
+     *            the z component
      * @param w
-     *          the value of w
+     *            the w component
      */
     public Vector4d(double x, double y, double z, double w) {
         this.x = x;
@@ -188,7 +198,8 @@ public class Vector4d implements Externalizable {
      * the vector is read, you can use {@link #Vector4d(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      * @see #Vector4d(int, ByteBuffer)
      */
     public Vector4d(ByteBuffer buffer) {
@@ -275,8 +286,8 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Set the first three components of this to the components of
-     * <code>v</code> and the last component to <code>w</code>.
+     * Set the x, y, and z components of this to the components of
+     * <code>v</code> and the w component to <code>w</code>.
      * 
      * @param v
      *            the {@link Vector3d} to copy
@@ -293,8 +304,8 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Set the first three components of this to the components of
-     * <code>v</code> and the last component to <code>w</code>.
+     * Set the x, y, and z components of this to the components of
+     * <code>v</code> and the w component to <code>w</code>.
      * 
      * @param v
      *            the {@link Vector3f} to copy
@@ -311,15 +322,15 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Set the first two components from the given <code>v</code>
-     * and the last two components from the given <code>z</code> and <code>w</code>.
+     * Set the x and y components from the given <code>v</code>>
+     * and the z and w components to the given <code>z</code> and <code>w</code>.
      *
      * @param v
      *            the {@link Vector2d}
      * @param z
-     *            the z value
+     *            the z component
      * @param w
-     *            the w value
+     *            the w component
      * @return this
      */
     public Vector4d set(Vector2d v, double z, double w) {
@@ -331,12 +342,15 @@ public class Vector4d implements Externalizable {
     }
     
     /**
-     * Set the first two components from the given <code>v</code>
-     * and the last two components from the given <code>z</code> and <code>w</code>.
+     * Set the x and y components from the given <code>v</code>
+     * and the z and w components to the given <code>z</code> and <code>w</code>.
      *
-     * @param v the {@link Vector2f}
-     * @param z the z value
-     * @param w the w value
+     * @param v
+     *            the {@link Vector2f}
+     * @param z
+     *            the z components
+     * @param w
+     *            the w components
      * @return this
      */
     public Vector4d set(Vector2f v, double z, double w) {
@@ -348,14 +362,24 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Set the components of this vector to the given values.
+     * Set the x, y, z, and w attributes to the supplied value.
+     *
+     * @param d
+     *          the value of all four components
+     */
+    public Vector4d set(double d) {
+        return set(d, d, d, d);
+    }
+
+    /**
+     * Set the x, y, z, and w attributes to the supplied values.
      * 
      * @param x
-     *            the x-component
+     *            the x component
      * @param y
-     *            the y-component
+     *            the y component
      * @param z
-     *            the z-component
+     *            the z component
      * @param w
      *            the w component
      * @return this

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -322,7 +322,7 @@ public class Vector4d implements Externalizable {
     }
 
     /**
-     * Set the x and y components from the given <code>v</code>>
+     * Set the x and y components from the given <code>v</code>
      * and the z and w components to the given <code>z</code> and <code>w</code>.
      *
      * @param v
@@ -366,6 +366,7 @@ public class Vector4d implements Externalizable {
      *
      * @param d
      *          the value of all four components
+     * @return this
      */
     public Vector4d set(double d) {
         return set(d, d, d, d);

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -43,19 +43,19 @@ public class Vector4f implements Externalizable {
     private static final long serialVersionUID = 1L;   
 
     /**
-     * The x-coordinate of the vector.
+     * The x component of the vector.
      */
     public float x;
     /**
-     * The y-coordinate of the vector.
+     * The y component of the vector.
      */
     public float y;
     /**
-     * The z-coordinate of the vector.
+     * The z component of the vector.
      */
     public float z;
     /**
-     * The w-coordinate of the vector.
+     * The w component of the vector.
      */
     public float w = 1.0f;
 
@@ -85,7 +85,7 @@ public class Vector4f implements Externalizable {
      * @param v
      *            the {@link Vector3f}
      * @param w
-     *            the w value
+     *            the w component
      */
     public Vector4f(Vector3f v, float w) {
         this.x = v.x;
@@ -101,9 +101,9 @@ public class Vector4f implements Externalizable {
      * @param v
      *            the {@link Vector2f}
      * @param z
-     *            the z value
+     *            the z component
      * @param w
-     *            the w value
+     *            the w component
      */
     public Vector4f(Vector2f v, float z, float w) {
         this.x = v.x;
@@ -113,16 +113,26 @@ public class Vector4f implements Externalizable {
     }
 
     /**
+     * Create a new {@link Vector4f} and initialize all four components with the given value.
+     *
+     * @param d
+     *            the value of all four components
+     */
+    public Vector4f(float d) {
+        this(d, d, d, d);
+    }
+    
+    /**
      * Create a new {@link Vector4f} with the given component values.
      * 
      * @param x
-     *          the value of x
+     *            the x component
      * @param y
-     *          the value of y
+     *            the y component
      * @param z
-     *          the value of z
+     *            the z component
      * @param w
-     *          the value of w
+     *            the w component
      */
     public Vector4f(float x, float y, float z, float w) {
         this.x = x;
@@ -141,7 +151,8 @@ public class Vector4f implements Externalizable {
      * the vector is read, you can use {@link #Vector4f(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      * @see #Vector4f(int, ByteBuffer)
      */
     public Vector4f(ByteBuffer buffer) {
@@ -154,8 +165,10 @@ public class Vector4f implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param index 
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      */
     public Vector4f(int index, ByteBuffer buffer) {
         x = buffer.getFloat(index);
@@ -174,7 +187,8 @@ public class Vector4f implements Externalizable {
      * the vector is read, you can use {@link #Vector4f(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      * @see #Vector4f(int, FloatBuffer)
      */
     public Vector4f(FloatBuffer buffer) {
@@ -187,8 +201,10 @@ public class Vector4f implements Externalizable {
      * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
-     * @param index  the absolute position into the FloatBuffer
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param index 
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      */
     public Vector4f(int index, FloatBuffer buffer) {
         x = buffer.get(index);
@@ -237,9 +253,9 @@ public class Vector4f implements Externalizable {
      * @param v
      *            the {@link Vector2f}
      * @param z
-     *            the z value
+     *            the z component
      * @param w
-     *            the w value
+     *            the w component
      * @return this
      */
     public Vector4f set(Vector2f v, float z, float w) {
@@ -251,14 +267,24 @@ public class Vector4f implements Externalizable {
     }
 
     /**
-     * Set the components of this vector to the given values.
+     * Set the x, y, z, and w components to the supplied value.
+     *
+     * @param d
+     *            the value of all four components
+     */
+    public Vector4f set(float d) {
+        return set(d, d, d, d);
+    }
+
+    /**
+     * Set the x, y, z, and w components to the supplied values.
      * 
      * @param x
-     *            the x-component
+     *            the x component
      * @param y
-     *            the y-component
+     *            the y component
      * @param z
-     *            the z-component
+     *            the z component
      * @param w
      *            the w component
      * @return this
@@ -281,7 +307,8 @@ public class Vector4f implements Externalizable {
      * the vector is read, you can use {@link #set(int, ByteBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      * @return this
      * @see #set(int, ByteBuffer)
      */
@@ -295,8 +322,10 @@ public class Vector4f implements Externalizable {
      * <p>
      * This method will not increment the position of the given ByteBuffer.
      *
-     * @param index  the absolute position into the ByteBuffer
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param index
+     *            the absolute position into the ByteBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f set(int index, ByteBuffer buffer) {
@@ -317,7 +346,8 @@ public class Vector4f implements Externalizable {
      * the vector is read, you can use {@link #set(int, FloatBuffer)}, taking
      * the absolute position as parameter.
      *
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      * @return this
      * @see #set(int, FloatBuffer)
      */
@@ -331,8 +361,10 @@ public class Vector4f implements Externalizable {
      * <p>
      * This method will not increment the position of the given FloatBuffer.
      *
-     * @param index  the absolute position into the FloatBuffer
-     * @param buffer values will be read in <tt>x, y, z, w</tt> order
+     * @param index 
+     *            the absolute position into the FloatBuffer
+     * @param buffer
+     *            values will be read in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f set(int index, FloatBuffer buffer) {
@@ -427,7 +459,7 @@ public class Vector4f implements Externalizable {
      * Subtract the supplied vector from this one.
      * 
      * @param v
-     *          the vector to subtract
+     *            the vector to subtract
      * @return this
      */
     public Vector4f sub(Vector4f v) {
@@ -442,13 +474,13 @@ public class Vector4f implements Externalizable {
      * Subtract <tt>(x, y, z, w)</tt> from this.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *            the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *            the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *            the z component to subtract
      * @param w
-     *          the w-coordinate to subtract
+     *            the w component to subtract
      * @return this
      */
     public Vector4f sub(float x, float y, float z, float w) {
@@ -463,9 +495,9 @@ public class Vector4f implements Externalizable {
      * Subtract the supplied vector from this one and store the result in <code>dest</code>.
      * 
      * @param v
-     *          the vector to subtract from <code>this</code>
+     *            the vector to subtract from <code>this</code>
      * @param dest
-     *          will hold the result
+     *            will hold the result
      * @return this
      */
     public Vector4f sub(Vector4f v, Vector4f dest) {
@@ -480,13 +512,13 @@ public class Vector4f implements Externalizable {
      * Subtract <tt>(x, y, z, w)</tt> from this and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to subtract
+     *            the x component to subtract
      * @param y
-     *          the y-coordinate to subtract
+     *            the y component to subtract
      * @param z
-     *          the z-coordinate to subtract
+     *            the z component to subtract
      * @param w
-     *          the w-coordinate to subtract
+     *            the w component to subtract
      * @param dest
      *          will hold the result
      * @return this
@@ -535,13 +567,13 @@ public class Vector4f implements Externalizable {
      * Increment the components of this vector by the given values.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @param z
-     *          the z-coordinate to add
+     *          the z component to add
      * @param w
-     *          the w-coordinate to add
+     *          the w component to add
      * @return this
      */
     public Vector4f add(float x, float y, float z, float w) {
@@ -556,13 +588,13 @@ public class Vector4f implements Externalizable {
      * Increment the components of this vector by the given values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to add
+     *          the x component to add
      * @param y
-     *          the y-coordinate to add
+     *          the y component to add
      * @param z
-     *          the z-coordinate to add
+     *          the z component to add
      * @param w
-     *          the w-coordinate to add
+     *          the w component to add
      * @param dest
      *          will hold the result
      * @return this
@@ -788,13 +820,13 @@ public class Vector4f implements Externalizable {
      * Multiply the components of this Vector4f by the given scalar values and store the result in <code>this</code>.
      * 
      * @param x
-     *          the x-coordinate to multiply by
+     *          the x component to multiply by
      * @param y
-     *          the y-coordinate to multiply by
+     *          the y component to multiply by
      * @param z
-     *          the z-coordinate to multiply by
+     *          the z component to multiply by
      * @param w
-     *          the w-coordinate to multiply by
+     *          the w component to multiply by
      * @return this
      */
     public Vector4f mul(float x, float y, float z, float w) {
@@ -809,13 +841,13 @@ public class Vector4f implements Externalizable {
      * Multiply the components of this Vector4f by the given scalar values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to multiply by
+     *          the x component to multiply by
      * @param y
-     *          the y-coordinate to multiply by
+     *          the y component to multiply by
      * @param z
-     *          the z-coordinate to multiply by
+     *          the z component to multiply by
      * @param w
-     *          the w-coordinate to multiply by
+     *          the w component to multiply by
      * @param dest
      *          will hold the result
      * @return this
@@ -866,13 +898,13 @@ public class Vector4f implements Externalizable {
      * Divide the components of this Vector4f by the given scalar values and store the result in <code>this</code>.
      * 
      * @param x
-     *          the x-coordinate to divide by
+     *          the x component to divide by
      * @param y
-     *          the y-coordinate to divide by
+     *          the y component to divide by
      * @param z
-     *          the z-coordinate to divide by
+     *          the z component to divide by
      * @param w
-     *          the w-coordinate to divide by
+     *          the w component to divide by
      * @return this
      */
     public Vector4f div(float x, float y, float z, float w) {
@@ -887,13 +919,13 @@ public class Vector4f implements Externalizable {
      * Divide the components of this Vector4f by the given scalar values and store the result in <code>dest</code>.
      * 
      * @param x
-     *          the x-coordinate to divide by
+     *          the x component to divide by
      * @param y
-     *          the y-coordinate to divide by
+     *          the y component to divide by
      * @param z
-     *          the z-coordinate to divide by
+     *          the z component to divide by
      * @param w
-     *          the w-coordinate to divide by
+     *          the w component to divide by
      * @param dest
      *          will hold the result
      * @return this
@@ -1032,13 +1064,13 @@ public class Vector4f implements Externalizable {
      * Return the distance between <code>this</code> vector and <tt>(x, y, z, w)</tt>.
      * 
      * @param x
-     *            the x-coordinate of the other vector
+     *            the x component of the other vector
      * @param y
-     *            the y-coordinate of the other vector
+     *            the y component of the other vector
      * @param z
-     *            the z-coordinate of the other vector
+     *            the z component of the other vector
      * @param w
-     *            the w-coordinate of the other vector
+     *            the w component of the other vector
      * @return the euclidean distance
      */
     public float distance(float x, float y, float z, float w) {
@@ -1065,13 +1097,13 @@ public class Vector4f implements Externalizable {
      * Compute the dot product (inner product) of this vector and <tt>(x, y, z, w)</tt>.
      * 
      * @param x
-     *            the x-coordinate of the other vector
+     *            the x component of the other vector
      * @param y
-     *            the y-coordinate of the other vector
+     *            the y component of the other vector
      * @param z
-     *            the z-coordinate of the other vector
+     *            the z component of the other vector
      * @param w
-     *            the w-coordinate of the other vector
+     *            the w component of the other vector
      * @return the dot product
      */
     public float dot(float x, float y, float z, float w) {

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -271,6 +271,7 @@ public class Vector4f implements Externalizable {
      *
      * @param d
      *          the value of all four components
+     * @return this
      */
     public Vector4f set(float d) {
         return set(d, d, d, d);

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -69,7 +69,7 @@ public class Vector4f implements Externalizable {
      * Create a new {@link Vector4f} with the same values as <code>v</code>.
      * 
      * @param v
-     *            the {@link Vector4f} to copy the values from
+     *          the {@link Vector4f} to copy the values from
      */
     public Vector4f(Vector4f v) {
         this.x = v.x;
@@ -83,9 +83,9 @@ public class Vector4f implements Externalizable {
      * given <code>v</code> and the given <code>w</code>.
      * 
      * @param v
-     *            the {@link Vector3f}
+     *          the {@link Vector3f}
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4f(Vector3f v, float w) {
         this.x = v.x;
@@ -99,11 +99,11 @@ public class Vector4f implements Externalizable {
      * given <code>v</code> and the given <code>z</code>, and <code>w</code>.
      * 
      * @param v
-     *            the {@link Vector2f}
+     *          the {@link Vector2f}
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4f(Vector2f v, float z, float w) {
         this.x = v.x;
@@ -116,7 +116,7 @@ public class Vector4f implements Externalizable {
      * Create a new {@link Vector4f} and initialize all four components with the given value.
      *
      * @param d
-     *            the value of all four components
+     *          the value of all four components
      */
     public Vector4f(float d) {
         this(d, d, d, d);
@@ -126,13 +126,13 @@ public class Vector4f implements Externalizable {
      * Create a new {@link Vector4f} with the given component values.
      * 
      * @param x
-     *            the x component
+     *          the x component
      * @param y
-     *            the y component
+     *          the y component
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      */
     public Vector4f(float x, float y, float z, float w) {
         this.x = x;
@@ -152,7 +152,7 @@ public class Vector4f implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      * @see #Vector4f(int, ByteBuffer)
      */
     public Vector4f(ByteBuffer buffer) {
@@ -166,9 +166,9 @@ public class Vector4f implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index 
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      */
     public Vector4f(int index, ByteBuffer buffer) {
         x = buffer.getFloat(index);
@@ -188,7 +188,7 @@ public class Vector4f implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      * @see #Vector4f(int, FloatBuffer)
      */
     public Vector4f(FloatBuffer buffer) {
@@ -202,9 +202,9 @@ public class Vector4f implements Externalizable {
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index 
-     *            the absolute position into the FloatBuffer
+     *          the absolute position into the FloatBuffer
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      */
     public Vector4f(int index, FloatBuffer buffer) {
         x = buffer.get(index);
@@ -217,7 +217,7 @@ public class Vector4f implements Externalizable {
      * Set this {@link Vector4f} to the values of the given <code>v</code>.
      * 
      * @param v
-     *            the vector whose values will be copied into this
+     *          the vector whose values will be copied into this
      * @return this
      */
     public Vector4f set(Vector4f v) {
@@ -233,9 +233,9 @@ public class Vector4f implements Externalizable {
      * <code>v</code> and the last component to <code>w</code>.
      * 
      * @param v
-     *            the {@link Vector3f} to copy
+     *          the {@link Vector3f} to copy
      * @param w
-     *            the w component
+     *          the w component
      * @return this
      */
     public Vector4f set(Vector3f v, float w) {
@@ -251,11 +251,11 @@ public class Vector4f implements Externalizable {
      * and last two components to the given <code>z</code>, and <code>w</code>.
      *
      * @param v
-     *            the {@link Vector2f}
+     *          the {@link Vector2f}
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      * @return this
      */
     public Vector4f set(Vector2f v, float z, float w) {
@@ -270,7 +270,7 @@ public class Vector4f implements Externalizable {
      * Set the x, y, z, and w components to the supplied value.
      *
      * @param d
-     *            the value of all four components
+     *          the value of all four components
      */
     public Vector4f set(float d) {
         return set(d, d, d, d);
@@ -280,13 +280,13 @@ public class Vector4f implements Externalizable {
      * Set the x, y, z, and w components to the supplied values.
      * 
      * @param x
-     *            the x component
+     *          the x component
      * @param y
-     *            the y component
+     *          the y component
      * @param z
-     *            the z component
+     *          the z component
      * @param w
-     *            the w component
+     *          the w component
      * @return this
      */
     public Vector4f set(float x, float y, float z, float w) {
@@ -308,7 +308,7 @@ public class Vector4f implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      * @return this
      * @see #set(int, ByteBuffer)
      */
@@ -323,9 +323,9 @@ public class Vector4f implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      *
      * @param index
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f set(int index, ByteBuffer buffer) {
@@ -347,7 +347,7 @@ public class Vector4f implements Externalizable {
      * the absolute position as parameter.
      *
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      * @return this
      * @see #set(int, FloatBuffer)
      */
@@ -362,9 +362,9 @@ public class Vector4f implements Externalizable {
      * This method will not increment the position of the given FloatBuffer.
      *
      * @param index 
-     *            the absolute position into the FloatBuffer
+     *          the absolute position into the FloatBuffer
      * @param buffer
-     *            values will be read in <tt>x, y, z, w</tt> order
+     *          values will be read in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f set(int index, FloatBuffer buffer) {
@@ -388,7 +388,7 @@ public class Vector4f implements Externalizable {
      * @see #get(int, FloatBuffer)
      * 
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z, w</tt> order
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f get(FloatBuffer buffer) {
@@ -402,9 +402,9 @@ public class Vector4f implements Externalizable {
      * This method will not increment the position of the given FloatBuffer.
      * 
      * @param index
-     *            the absolute position into the FloatBuffer
+     *          the absolute position into the FloatBuffer
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z, w</tt> order
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f get(int index, FloatBuffer buffer) {
@@ -428,7 +428,7 @@ public class Vector4f implements Externalizable {
      * @see #get(int, ByteBuffer)
      * 
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z, w</tt> order
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f get(ByteBuffer buffer) {
@@ -442,9 +442,9 @@ public class Vector4f implements Externalizable {
      * This method will not increment the position of the given ByteBuffer.
      * 
      * @param index
-     *            the absolute position into the ByteBuffer
+     *          the absolute position into the ByteBuffer
      * @param buffer
-     *            will receive the values of this vector in <tt>x, y, z, w</tt> order
+     *          will receive the values of this vector in <tt>x, y, z, w</tt> order
      * @return this
      */
     public Vector4f get(int index, ByteBuffer buffer) {
@@ -459,7 +459,7 @@ public class Vector4f implements Externalizable {
      * Subtract the supplied vector from this one.
      * 
      * @param v
-     *            the vector to subtract
+     *          the vector to subtract
      * @return this
      */
     public Vector4f sub(Vector4f v) {
@@ -474,13 +474,13 @@ public class Vector4f implements Externalizable {
      * Subtract <tt>(x, y, z, w)</tt> from this.
      * 
      * @param x
-     *            the x component to subtract
+     *          the x component to subtract
      * @param y
-     *            the y component to subtract
+     *          the y component to subtract
      * @param z
-     *            the z component to subtract
+     *          the z component to subtract
      * @param w
-     *            the w component to subtract
+     *          the w component to subtract
      * @return this
      */
     public Vector4f sub(float x, float y, float z, float w) {
@@ -495,9 +495,9 @@ public class Vector4f implements Externalizable {
      * Subtract the supplied vector from this one and store the result in <code>dest</code>.
      * 
      * @param v
-     *            the vector to subtract from <code>this</code>
+     *          the vector to subtract from <code>this</code>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector4f sub(Vector4f v, Vector4f dest) {
@@ -512,13 +512,13 @@ public class Vector4f implements Externalizable {
      * Subtract <tt>(x, y, z, w)</tt> from this and store the result in <code>dest</code>.
      * 
      * @param x
-     *            the x component to subtract
+     *          the x component to subtract
      * @param y
-     *            the y component to subtract
+     *          the y component to subtract
      * @param z
-     *            the z component to subtract
+     *          the z component to subtract
      * @param w
-     *            the w component to subtract
+     *          the w component to subtract
      * @param dest
      *          will hold the result
      * @return this
@@ -750,7 +750,7 @@ public class Vector4f implements Externalizable {
      * <code>this</code>.
      * 
      * @param mat
-     *            the matrix to multiply the vector with
+     *          the matrix to multiply the vector with
      * @return this
      */
     public Vector4f mul(Matrix4f mat) {
@@ -762,9 +762,9 @@ public class Vector4f implements Externalizable {
      * <code>dest</code>.
      * 
      * @param mat
-     *            the matrix to multiply the vector with
+     *          the matrix to multiply the vector with
      * @param dest
-     *            the destination vector to hold the result
+     *          the destination vector to hold the result
      * @return this
      */
     public Vector4f mul(Matrix4f mat, Vector4f dest) {
@@ -1064,13 +1064,13 @@ public class Vector4f implements Externalizable {
      * Return the distance between <code>this</code> vector and <tt>(x, y, z, w)</tt>.
      * 
      * @param x
-     *            the x component of the other vector
+     *          the x component of the other vector
      * @param y
-     *            the y component of the other vector
+     *          the y component of the other vector
      * @param z
-     *            the z component of the other vector
+     *          the z component of the other vector
      * @param w
-     *            the w component of the other vector
+     *          the w component of the other vector
      * @return the euclidean distance
      */
     public float distance(float x, float y, float z, float w) {
@@ -1086,7 +1086,7 @@ public class Vector4f implements Externalizable {
      * .
      * 
      * @param v
-     *            the other vector
+     *          the other vector
      * @return the dot product
      */
     public float dot(Vector4f v) {
@@ -1097,13 +1097,13 @@ public class Vector4f implements Externalizable {
      * Compute the dot product (inner product) of this vector and <tt>(x, y, z, w)</tt>.
      * 
      * @param x
-     *            the x component of the other vector
+     *          the x component of the other vector
      * @param y
-     *            the y component of the other vector
+     *          the y component of the other vector
      * @param z
-     *            the z component of the other vector
+     *          the z component of the other vector
      * @param w
-     *            the w component of the other vector
+     *          the w component of the other vector
      * @return the dot product
      */
     public float dot(float x, float y, float z, float w) {
@@ -1226,7 +1226,7 @@ public class Vector4f implements Externalizable {
      * this and the other vector.
      *
      * @param v
-     *            the other vector
+     *          the other vector
      * @return this
      */
     public Vector4f min(Vector4f v) {
@@ -1242,7 +1242,7 @@ public class Vector4f implements Externalizable {
      * this and the other vector.
      *
      * @param v
-     *            the other vector
+     *          the other vector
      * @return this
      */
     public Vector4f max(Vector4f v) {
@@ -1288,11 +1288,11 @@ public class Vector4f implements Externalizable {
      * store the result in <code>dest</code>.
      * 
      * @param v
-     *            the other vector
+     *          the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector4f smoothStep(Vector4d v, float t, Vector4f dest) {
@@ -1310,15 +1310,15 @@ public class Vector4f implements Externalizable {
      * <code>dest</code>.
      * 
      * @param t0
-     *            the tangent of <code>this</code> vector
+     *          the tangent of <code>this</code> vector
      * @param v1
-     *            the other vector
+     *          the other vector
      * @param t1
-     *            the tangent of the other vector
+     *          the tangent of the other vector
      * @param t
-     *            the interpolation factor, within <tt>[0..1]</tt>
+     *          the interpolation factor, within <tt>[0..1]</tt>
      * @param dest
-     *            will hold the result
+     *          will hold the result
      * @return this
      */
     public Vector4f hermite(Vector4f t0, Vector4f v1, Vector4f t1, double t, Vector4f dest) {


### PR DESCRIPTION
- All Vector's constructors and set methods take a single value to initialize all components
- Normalized all javadoc argument description to an indent of 9 spaces.
- All references to x, y, z, and w use the word component instead of value or coordinate.
