### PR TITLE
Fix for incorrect div and mul methods in Vector4d

### DIFF
--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -1063,10 +1063,10 @@ public class Vector4d implements Externalizable {
      * @return dest
      */
     public Vector4d mul(double scalar, Vector4d dest) {
-        x *= scalar;
-        y *= scalar;
-        z *= scalar;
-        w *= scalar;
+        dest.x = x * scalar;
+        dest.y = y * scalar;
+        dest.z = z * scalar;
+        dest.w = w * scalar;
         return dest;
     }
 
@@ -1095,10 +1095,10 @@ public class Vector4d implements Externalizable {
      * @return dest
      */
     public Vector4d div(double scalar, Vector4d dest) {
-        x /= scalar;
-        y /= scalar;
-        z /= scalar;
-        w /= scalar;
+        dest.x = x / scalar;
+        dest.y = y / scalar;
+        dest.z = z / scalar;
+        dest.w = w / scalar;
         return dest;
     }
 

--- a/test/org/joml/test/Vector4dTest.java
+++ b/test/org/joml/test/Vector4dTest.java
@@ -22,4 +22,22 @@ public class Vector4dTest extends TestCase {
         angle = testVec1.angle(testVec2);
         assertEquals(Math.PI, angle, TestUtil.MANY_OPS_AROUND_ZERO_PRECISION_DOUBLE);
     }
+
+    public void testMulByScalarIntoDest() {
+        Vector4d testVec1 = new Vector4d(2, 2, 2, 2);
+        Vector4d destVec = new Vector4d(0, 0, 0, 0);
+
+        testVec1.mul(2, destVec);
+        assertEquals(new Vector4d(4, 4, 4, 4), destVec);
+        assertEquals(new Vector4d(2, 2, 2, 2), testVec1);
+    }
+
+    public void testDivByScalarIntoDest() {
+        Vector4d testVec1 = new Vector4d(2, 2, 2, 2);
+        Vector4d destVec = new Vector4d(0, 0, 0, 0);
+
+        testVec1.div(2, destVec);
+        assertEquals(new Vector4d(1, 1, 1, 1), destVec);
+        assertEquals(new Vector4d(2, 2, 2, 2), testVec1);
+    }
 }


### PR DESCRIPTION
Fixes an issue with Vector4d's mul(double, Vector4d) and div(double, Vector4d) - they incorrectly alter the called object rather than update the provided destination Vector4d.