### PR TITLE
Fix incorrect return value from Quaternion#rotateTo

### DIFF
--- a/src/org/joml/Quaterniond.java
+++ b/src/org/joml/Quaterniond.java
@@ -1834,7 +1834,7 @@ public class Quaterniond implements Externalizable {
             w *= invNorm;
         } else {
             /* vectors are parallel, don't change anything */
-            return this;
+            return dest;
         }
         /* Multiply */
         dest.set(this.w * x + this.x * w + this.y * z - this.z * y,

--- a/src/org/joml/Quaternionf.java
+++ b/src/org/joml/Quaternionf.java
@@ -2055,7 +2055,7 @@ public class Quaternionf implements Externalizable {
             w *= invNorm;
         } else {
             /* vectors are parallel, don't change anything */
-            return this;
+            return dest;
         }
         /* Multiply */
         dest.set(this.w * x + this.x * w + this.y * z - this.z * y,

--- a/test/org/joml/test/QuaternionDTest.java
+++ b/test/org/joml/test/QuaternionDTest.java
@@ -73,4 +73,11 @@ public class QuaternionDTest extends TestCase {
         TestUtil.assertMatrix4fEquals(m, n, 1E-6f);
     }
 
+    public void testRotateToReturnsDestination() {
+        Quaterniond rotation = new Quaterniond();
+        Quaterniond destination = new Quaterniond();
+        Quaterniond result = rotation.rotateTo(0, 1, 0, 0, 1, 0, destination);
+        assertSame(destination, result);
+    }
+
 }

--- a/test/org/joml/test/QuaternionTest.java
+++ b/test/org/joml/test/QuaternionTest.java
@@ -103,4 +103,11 @@ public class QuaternionTest extends TestCase {
         TestUtil.assertMatrix4fEquals(m, n, 1E-6f);
     }
 
+    public void testRotateToReturnsDestination() {
+        Quaternionf rotation = new Quaternionf();
+        Quaternionf destination = new Quaternionf();
+        Quaternionf result = rotation.rotateTo(0, 1, 0, 0, 1, 0, destination);
+        assertSame(destination, result);
+    }
+
 }


### PR DESCRIPTION
Fixed a situation where Quaternionf#rotateTo and Quaterniond#rotateTo would return ```this``` rather than the destination Quaternion.