### PR TITLE
Add the setComponent(component, value) method to all vector classes

### DIFF
--- a/src/org/joml/Vector2d.java
+++ b/src/org/joml/Vector2d.java
@@ -417,6 +417,30 @@ public class Vector2d implements Externalizable, Vector2dc {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..1]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..1]</tt>
+     */
+    public Vector2d setComponent(int component, double value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector2dc#get(java.nio.ByteBuffer)
      */

--- a/src/org/joml/Vector2f.java
+++ b/src/org/joml/Vector2f.java
@@ -408,6 +408,30 @@ public class Vector2f implements Externalizable, Vector2fc {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..1]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..1]</tt>
+     */
+    public Vector2f setComponent(int component, float value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector2fc#get(java.nio.ByteBuffer)
      */

--- a/src/org/joml/Vector2i.java
+++ b/src/org/joml/Vector2i.java
@@ -398,6 +398,30 @@ public class Vector2i implements Externalizable, Vector2ic {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..1]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..1]</tt>
+     */
+    public Vector2i setComponent(int component, int value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector2ic#get(java.nio.ByteBuffer)
      */

--- a/src/org/joml/Vector3d.java
+++ b/src/org/joml/Vector3d.java
@@ -681,6 +681,33 @@ public class Vector3d implements Externalizable, Vector3dc {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..2]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
+     */
+    public Vector3d setComponent(int component, double value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            case 2:
+                z = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector3dc#get(java.nio.ByteBuffer)
      */
@@ -2111,33 +2138,6 @@ public class Vector3d implements Externalizable, Vector3dc {
         default:
             throw new IllegalArgumentException();
         }
-    }
-
-    /**
-     * Set the value of the specified component of this vector.
-     * 
-     * @param component
-     *          the component whose value to set, within <tt>[0..2]</tt>
-     * @param value
-     *          the value to set
-     * @return this
-     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
-     */
-    public Vector3d set(int component, double value) throws IllegalArgumentException {
-        switch (component) {
-        case 0:
-            x = value;
-            break;
-        case 1:
-            y = value;
-            break;
-        case 2:
-            z = value;
-            break;
-        default:
-            throw new IllegalArgumentException();
-        }
-        return this;
     }
 
     /* (non-Javadoc)

--- a/src/org/joml/Vector3f.java
+++ b/src/org/joml/Vector3f.java
@@ -585,6 +585,33 @@ public class Vector3f implements Externalizable, Vector3fc {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..2]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
+     */
+    public Vector3f setComponent(int component, float value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            case 2:
+                z = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector3fc#get(java.nio.FloatBuffer)
      */
@@ -1636,33 +1663,6 @@ public class Vector3f implements Externalizable, Vector3fc {
         default:
             throw new IllegalArgumentException();
         }
-    }
-
-    /**
-     * Set the value of the specified component of this vector.
-     * 
-     * @param component
-     *          the component whose value to set, within <tt>[0..2]</tt>
-     * @param value
-     *          the value to set
-     * @return this
-     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
-     */
-    public Vector3f set(int component, float value) throws IllegalArgumentException {
-        switch (component) {
-        case 0:
-            x = value;
-            break;
-        case 1:
-            y = value;
-            break;
-        case 2:
-            z = value;
-            break;
-        default:
-            throw new IllegalArgumentException();
-        }
-        return this;
     }
 
     /* (non-Javadoc)

--- a/src/org/joml/Vector3i.java
+++ b/src/org/joml/Vector3i.java
@@ -451,6 +451,33 @@ public class Vector3i implements Externalizable, Vector3ic {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..2]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..2]</tt>
+     */
+    public Vector3i setComponent(int component, int value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            case 2:
+                z = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector3ic#get(java.nio.IntBuffer)
      */

--- a/src/org/joml/Vector4d.java
+++ b/src/org/joml/Vector4d.java
@@ -639,6 +639,36 @@ public class Vector4d implements Externalizable, Vector4dc {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..3]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..3]</tt>
+     */
+    public Vector4d setComponent(int component, double value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            case 2:
+                z = value;
+                break;
+            case 3:
+                w = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector4dc#get(java.nio.ByteBuffer)
      */

--- a/src/org/joml/Vector4f.java
+++ b/src/org/joml/Vector4f.java
@@ -576,6 +576,36 @@ public class Vector4f implements Externalizable, Vector4fc {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..3]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..3]</tt>
+     */
+    public Vector4f setComponent(int component, float value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            case 2:
+                z = value;
+                break;
+            case 3:
+                w = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector4fc#get(java.nio.FloatBuffer)
      */

--- a/src/org/joml/Vector4i.java
+++ b/src/org/joml/Vector4i.java
@@ -516,6 +516,36 @@ public class Vector4i implements Externalizable, Vector4ic {
         return this;
     }
 
+    /**
+     * Set the value of the specified component of this vector.
+     *
+     * @param component
+     *          the component whose value to set, within <tt>[0..3]</tt>
+     * @param value
+     *          the value to set
+     * @return this
+     * @throws IllegalArgumentException if <code>component</code> is not within <tt>[0..3]</tt>
+     */
+    public Vector4i setComponent(int component, int value) throws IllegalArgumentException {
+        switch (component) {
+            case 0:
+                x = value;
+                break;
+            case 1:
+                y = value;
+                break;
+            case 2:
+                z = value;
+                break;
+            case 3:
+                w = value;
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+        return this;
+    }
+
     /* (non-Javadoc)
      * @see org.joml.Vector4ic#get(java.nio.IntBuffer)
      */


### PR DESCRIPTION
In Vector3f and Vector3d there is already a method to set the value of a component by an index, e.g. in Vector3f: `public Vector3f set(int component, float value)`
But is was missing in the other vector classes, so i think it should be in every vector class for more consistency.
Problem is that in Vector2i there is already a mthod `set(int, int)` that has another purpose, that is why another method name was needed ->setComponent.