### PR TITLE
Fix Quaternionf and Quaterniond constructor

### DIFF
--- a/src/org/joml/Quaterniond.java
+++ b/src/org/joml/Quaterniond.java
@@ -30,6 +30,7 @@ import java.io.ObjectOutput;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
+import org.joml.internal.MemUtil;
 import org.joml.internal.Options;
 import org.joml.internal.Runtime;
 
@@ -94,10 +95,14 @@ public class Quaterniond implements Externalizable, Quaterniondc {
      *          the {@link Quaterniond} to take the component values from
      */
     public Quaterniond(Quaterniondc source) {
-        x = source.x();
-        y = source.y();
-        z = source.z();
-        w = source.w();
+        if (source instanceof Quaterniond) {
+            MemUtil.INSTANCE.copy((Quaterniond) source, this);
+        } else {
+            this.x = source.x();
+            this.y = source.y();
+            this.z = source.z();
+            this.w = source.w();
+        }
     }
 
     /**
@@ -168,6 +173,7 @@ public class Quaterniond implements Externalizable, Quaterniondc {
     public double w() {
         return this.w;
     }
+
 
     /**
      * Normalize this quaternion.

--- a/src/org/joml/Quaternionf.java
+++ b/src/org/joml/Quaternionf.java
@@ -98,8 +98,15 @@ public class Quaternionf implements Externalizable, Quaternionfc {
      * @param source
      *          the {@link Quaternionf} to take the component values from
      */
-    public Quaternionf(Quaternionf source) {
-        MemUtil.INSTANCE.copy(source, this);
+    public Quaternionf(Quaternionfc source) {
+        if (source instanceof Quaternionf) {
+            MemUtil.INSTANCE.copy((Quaternionf) source, this);
+        } else {
+            this.x = source.x();
+            this.y = source.y();
+            this.z = source.z();
+            this.w = source.w();
+        }
     }
 
     /**

--- a/src/org/joml/internal/MemUtil.java
+++ b/src/org/joml/internal/MemUtil.java
@@ -44,6 +44,7 @@ import org.joml.Matrix4d;
 import org.joml.Matrix4f;
 import org.joml.Matrix4x3d;
 import org.joml.Matrix4x3f;
+import org.joml.Quaterniond;
 import org.joml.Quaternionf;
 import org.joml.Vector2d;
 import org.joml.Vector2f;
@@ -244,6 +245,7 @@ public abstract class MemUtil {
     public abstract void copy(Vector4f src, Vector4f dst);
     public abstract void copy(Vector4i src, Vector4i dst);
     public abstract void copy(Quaternionf src, Quaternionf dst);
+    public abstract void copy(Quaterniond src, Quaterniond dst);
     public abstract void copy(float[] arr, int off, Matrix4f dest);
     public abstract void copy(float[] arr, int off, Matrix3f dest);
     public abstract void copy(float[] arr, int off, Matrix4x3f dest);
@@ -2179,6 +2181,13 @@ public abstract class MemUtil {
         }
 
         public void copy(Quaternionf src, Quaternionf dst) {
+            dst.x = src.x;
+            dst.y = src.y;
+            dst.z = src.z;
+            dst.w = src.w;
+        }
+
+        public void copy(Quaterniond src, Quaterniond dst) {
             dst.x = src.x;
             dst.y = src.y;
             dst.z = src.z;


### PR DESCRIPTION
I changed Quaternionf and Quaterniond constructor to be more consistent with the rest of the library. I also added MemUtil copy method for Quaterniond.