### PR TITLE
Fix Export-Package of the OSGi metadata.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
 							<Bundle-Name>${project.name}</Bundle-Name>
 							<Bundle-SymbolicName>${project.groupId}</Bundle-SymbolicName>
 							<Bundle-Version>${project.version}</Bundle-Version>
-							<Export-Package>org.joml org.joml.sampling</Export-Package>
+							<Export-Package>org.joml,org.joml.sampling</Export-Package>
 						</manifestEntries>
 					</archive>
 				</configuration>


### PR DESCRIPTION
The OSGi specification defines the "comma" as separator for package export entries.
Currently, a blank is used which results in corrupted OSGI metadata and hence
JOML can not be used in an OSGi environment (no package is exported).