### PR TITLE
Add scaling functions to Rectangle* classes

### DIFF
--- a/src/org/joml/Rectangled.java
+++ b/src/org/joml/Rectangled.java
@@ -224,6 +224,249 @@ public class Rectangled implements Externalizable {
         return dest;
     }
 
+    /**
+     * Scale <code>this</code> about the origin.
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis.
+     * @return this
+     */
+    public Rectangled scale(double sf) {
+        return scale(sf, sf);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin and store the result in <code>dest</code>.
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectangled scale(double sf, Rectangled dest) {
+        return scale(sf, sf, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sf);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @return this
+     */
+    public Rectangled scale(double sf, double ax, double ay) {
+        return scale(sf, sf, ax, ay);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sf);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectangled scale(double sf, double ax, double ay, Rectangled dest) {
+        return scale(sf, sf, ax, ay, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sf);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param anchor
+     *          the location of the anchor
+     * @return this
+     */
+    public Rectangled scale(double sf, Vector2dc anchor) {
+        return scale(sf, anchor.x(), anchor.y());
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sf);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param anchor
+     *          the location of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectangled scale(double sf, Vector2dc anchor, Rectangled dest) {
+        return scale(sf, anchor.x(), anchor.y(), dest);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin.
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @return this
+     */
+    public Rectangled scale(double sx, double sy) {
+        return scale(sx, sy, 0d, 0d);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin and store the result in <code>dest</code>.
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectangled scale(double sx, double sy, Rectangled dest) {
+        return scale(sx, sy, 0d, 0d, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sx, sy);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @return this
+     */
+    public Rectangled scale(double sx, double sy, double ax, double ay) {
+        minX = (minX - ax) * sx + ax;
+        minY = (minY - ay) * sy + ay;
+        maxX = (maxX - ax) * sx + ax;
+        maxY = (maxY - ax) * sy + ay;
+        return this;
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sx, sy);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param anchor
+     *          the location of the anchor
+     * @return this
+     */
+    public Rectangled scale(double sx, double sy, Vector2dc anchor) {
+        return scale(sx, sy, anchor.x(), anchor.y());
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sx, sy);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectangled scale(double sx, double sy, double ax, double ay, Rectangled dest) {
+        dest.minX = (minX - ax) * sx + ax;
+        dest.minY = (minY - ay) * sy + ay;
+        dest.maxX = (maxX - ax) * sx + ax;
+        dest.maxY = (maxY - ax) * sy + ay;
+        return dest;
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sx, sy);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param anchor
+     *          the location of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectangled scale(double sx, double sy, Vector2dc anchor, Rectangled dest) {
+        return scale(sx, sy, anchor.x(), anchor.y(), dest);
+    }
+
     public int hashCode() {
         final int prime = 31;
         int result = 1;

--- a/src/org/joml/Rectangled.java
+++ b/src/org/joml/Rectangled.java
@@ -387,7 +387,7 @@ public class Rectangled implements Externalizable {
         minX = (minX - ax) * sx + ax;
         minY = (minY - ay) * sy + ay;
         maxX = (maxX - ax) * sx + ax;
-        maxY = (maxY - ax) * sy + ay;
+        maxY = (maxY - ay) * sy + ay;
         return this;
     }
 
@@ -439,7 +439,7 @@ public class Rectangled implements Externalizable {
         dest.minX = (minX - ax) * sx + ax;
         dest.minY = (minY - ay) * sy + ay;
         dest.maxX = (maxX - ax) * sx + ax;
-        dest.maxY = (maxY - ax) * sy + ay;
+        dest.maxY = (maxY - ay) * sy + ay;
         return dest;
     }
 

--- a/src/org/joml/Rectanglef.java
+++ b/src/org/joml/Rectanglef.java
@@ -200,6 +200,249 @@ public class Rectanglef implements Externalizable {
         return dest;
     }
 
+    /**
+     * Scale <code>this</code> about the origin.
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis.
+     * @return this
+     */
+    public Rectanglef scale(float sf) {
+        return scale(sf, sf);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin and store the result in <code>dest</code>.
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglef scale(float sf, Rectanglef dest) {
+        return scale(sf, sf, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sf);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @return this
+     */
+    public Rectanglef scale(float sf, float ax, float ay) {
+        return scale(sf, sf, ax, ay);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sf);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglef scale(float sf, float ax, float ay, Rectanglef dest) {
+        return scale(sf, sf, ax, ay, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sf);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param anchor
+     *          the location of the anchor
+     * @return this
+     */
+    public Rectanglef scale(float sf, Vector2fc anchor) {
+        return scale(sf, anchor.x(), anchor.y());
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sf);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param anchor
+     *          the location of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglef scale(float sf, Vector2fc anchor, Rectanglef dest) {
+        return scale(sf, anchor.x(), anchor.y(), dest);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin.
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @return this
+     */
+    public Rectanglef scale(float sx, float sy) {
+        return scale(sx, sy, 0f, 0f);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin and store the result in <code>dest</code>.
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglef scale(float sx, float sy, Rectanglef dest) {
+        return scale(sx, sy, 0f, 0f, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sx, sy);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @return this
+     */
+    public Rectanglef scale(float sx, float sy, float ax, float ay) {
+        minX = (minX - ax) * sx + ax;
+        minY = (minY - ay) * sy + ay;
+        maxX = (maxX - ax) * sx + ax;
+        maxY = (maxY - ax) * sy + ay;
+        return this;
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sx, sy);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param anchor
+     *          the location of the anchor
+     * @return this
+     */
+    public Rectanglef scale(float sx, float sy, Vector2fc anchor) {
+        return scale(sx, sy, anchor.x(), anchor.y());
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sx, sy);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglef scale(float sx, float sy, float ax, float ay, Rectanglef dest) {
+        dest.minX = (minX - ax) * sx + ax;
+        dest.minY = (minY - ay) * sy + ay;
+        dest.maxX = (maxX - ax) * sx + ax;
+        dest.maxY = (maxY - ax) * sy + ay;
+        return dest;
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sx, sy);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param anchor
+     *          the location of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglef scale(float sx, float sy, Vector2fc anchor, Rectanglef dest) {
+        return scale(sx, sy, anchor.x(), anchor.y(), dest);
+    }
+
     public int hashCode() {
         final int prime = 31;
         int result = 1;

--- a/src/org/joml/Rectanglef.java
+++ b/src/org/joml/Rectanglef.java
@@ -363,7 +363,7 @@ public class Rectanglef implements Externalizable {
         minX = (minX - ax) * sx + ax;
         minY = (minY - ay) * sy + ay;
         maxX = (maxX - ax) * sx + ax;
-        maxY = (maxY - ax) * sy + ay;
+        maxY = (maxY - ay) * sy + ay;
         return this;
     }
 
@@ -415,7 +415,7 @@ public class Rectanglef implements Externalizable {
         dest.minX = (minX - ax) * sx + ax;
         dest.minY = (minY - ay) * sy + ay;
         dest.maxX = (maxX - ax) * sx + ax;
-        dest.maxY = (maxY - ax) * sy + ay;
+        dest.maxY = (maxY - ay) * sy + ay;
         return dest;
     }
 

--- a/src/org/joml/Rectanglei.java
+++ b/src/org/joml/Rectanglei.java
@@ -199,6 +199,249 @@ public class Rectanglei implements Externalizable {
         return dest;
     }
 
+    /**
+     * Scale <code>this</code> about the origin.
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis.
+     * @return this
+     */
+    public Rectanglei scale(int sf) {
+        return scale(sf, sf);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin and store the result in <code>dest</code>.
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglei scale(int sf, Rectanglei dest) {
+        return scale(sf, sf, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sf);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @return this
+     */
+    public Rectanglei scale(int sf, int ax, int ay) {
+        return scale(sf, sf, ax, ay);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sf);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglei scale(int sf, int ax, int ay, Rectanglei dest) {
+        return scale(sf, sf, ax, ay, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sf);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param anchor
+     *          the location of the anchor
+     * @return this
+     */
+    public Rectanglei scale(int sf, Vector2ic anchor) {
+        return scale(sf, anchor.x(), anchor.y());
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is effectively equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sf);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sf
+     *          the scaling factor in the x and y axis
+     * @param anchor
+     *          the location of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglei scale(int sf, Vector2ic anchor, Rectanglei dest) {
+        return scale(sf, anchor.x(), anchor.y(), dest);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin.
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @return this
+     */
+    public Rectanglei scale(int sx, int sy) {
+        return scale(sx, sy, 0, 0);
+    }
+
+    /**
+     * Scale <code>this</code> about the origin and store the result in <code>dest</code>.
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglei scale(int sx, int sy, Rectanglei dest) {
+        return scale(sx, sy, 0, 0, dest);
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sx, sy);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @return this
+     */
+    public Rectanglei scale(int sx, int sy, int ax, int ay) {
+        minX = (minX - ax) * sx + ax;
+        minY = (minY - ay) * sy + ay;
+        maxX = (maxX - ax) * sx + ax;
+        maxY = (maxY - ay) * sy + ay;
+        return this;
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sx, sy);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param anchor
+     *          the location of the anchor
+     * @return this
+     */
+    public Rectanglei scale(int sx, int sy, Vector2ic anchor) {
+        return scale(sx, sy, anchor.x(), anchor.y());
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(-ax, -ay);
+     *     scale(sx, sy);
+     *     translate(ax, ay);
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param ax
+     *          the x coordinate of the anchor
+     * @param ay
+     *          the y coordinate of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglei scale(int sx, int sy, int ax, int ay, Rectanglei dest) {
+        dest.minX = (minX - ax) * sx + ax;
+        dest.minY = (minY - ay) * sy + ay;
+        dest.maxX = (maxX - ax) * sx + ax;
+        dest.maxY = (maxY - ay) * sy + ay;
+        return dest;
+    }
+
+    /**
+     * Scale <code>this</code> about an anchor and store the result in <code>dest</code>.
+     * <p>
+     * This is equivalent to <br>
+     * <pre>
+     *     translate(anchor.negate());
+     *     scale(sx, sy);
+     *     translate(anchor.negate());
+     * </pre>
+     *
+     * @param sx
+     *          the scaling factor on the x axis
+     * @param sy
+     *          the scaling factor on the y axis
+     * @param anchor
+     *          the location of the anchor
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    public Rectanglei scale(int sx, int sy, Vector2ic anchor, Rectanglei dest) {
+        return scale(sx, sy, anchor.x(), anchor.y(), dest);
+    }
+
     public int hashCode() {
         final int prime = 31;
         int result = 1;

--- a/test/org/joml/test/RectangleScaleTest.java
+++ b/test/org/joml/test/RectangleScaleTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 JOML.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.joml.test;
 
 import junit.framework.TestCase;
@@ -11,18 +34,7 @@ import org.joml.Rectanglei;
  */
 public class RectangleScaleTest extends TestCase {
 
-    static final float  F32_EPSILON = 1e-7f;
-    static final double F64_EPSILON = 1e-16d;
-
-    static boolean fpEqual (float a, float b) {
-        return Math.abs (a - b) <= F32_EPSILON;
-    }
-
-    static boolean fpEqual (double a, double b) {
-        return Math.abs (a - b) <= F64_EPSILON;
-    }
-
-    public void testNonUniformAnchoredScalingNoDestination () {
+    public static void testNonUniformAnchoredScalingNoDestination () {
         Rectangled testA = new Rectangled (-1, -1, +1, +1);
         Rectanglef testB = new Rectanglef (-1, -1, +1, +1);
         Rectanglei testC = new Rectanglei (-1, -1, +1, +1);
@@ -32,7 +44,7 @@ public class RectangleScaleTest extends TestCase {
         assertEquals (new Rectanglei (-1, -1, +3, +5), testC.scale (2, 3, -1, -1));
     }
 
-    public void testNonUniformAnchoredScalingWithDestination () {
+    public static void testNonUniformAnchoredScalingWithDestination () {
         Rectangled testASubject = new Rectangled (-1, -1, +1, +1);
         Rectangled testATarget  = new Rectangled ( 0,  0,  0,  0);
 

--- a/test/org/joml/test/RectangleScaleTest.java
+++ b/test/org/joml/test/RectangleScaleTest.java
@@ -1,0 +1,49 @@
+package org.joml.test;
+
+import junit.framework.TestCase;
+
+import org.joml.Rectangled;
+import org.joml.Rectanglef;
+import org.joml.Rectanglei;
+
+/**
+ * Tests of {@link Rectangled} scaling functions.
+ */
+public class RectangleScaleTest extends TestCase {
+
+    static final float  F32_EPSILON = 1e-7f;
+    static final double F64_EPSILON = 1e-16d;
+
+    static boolean fpEqual (float a, float b) {
+        return Math.abs (a - b) <= F32_EPSILON;
+    }
+
+    static boolean fpEqual (double a, double b) {
+        return Math.abs (a - b) <= F64_EPSILON;
+    }
+
+    public void testNonUniformAnchoredScalingNoDestination () {
+        Rectangled testA = new Rectangled (-1, -1, +1, +1);
+        Rectanglef testB = new Rectanglef (-1, -1, +1, +1);
+        Rectanglei testC = new Rectanglei (-1, -1, +1, +1);
+
+        assertEquals (new Rectangled (-1, -1, +3, +5), testA.scale (2, 3, -1, -1));
+        assertEquals (new Rectanglef (-1, -1, +3, +5), testB.scale (2, 3, -1, -1));
+        assertEquals (new Rectanglei (-1, -1, +3, +5), testC.scale (2, 3, -1, -1));
+    }
+
+    public void testNonUniformAnchoredScalingWithDestination () {
+        Rectangled testASubject = new Rectangled (-1, -1, +1, +1);
+        Rectangled testATarget  = new Rectangled ( 0,  0,  0,  0);
+
+        Rectanglef testBSubject = new Rectanglef (-1, -1, +1, +1);
+        Rectanglef testBTarget  = new Rectanglef ( 0,  0,  0,  0);
+
+        Rectanglei testCSubject = new Rectanglei (-1, -1, +1, +1);
+        Rectanglei testCTarget  = new Rectanglei ( 0,  0,  0,  0);
+
+        assertEquals (new Rectangled (-1, -1, +3, +5), testASubject.scale (2, 3, -1, -1, testATarget));
+        assertEquals (new Rectanglef (-1, -1, +3, +5), testBSubject.scale (2, 3, -1, -1, testBTarget));
+        assertEquals (new Rectanglei (-1, -1, +3, +5), testCSubject.scale (2, 3, -1, -1, testCTarget));
+    }
+}


### PR DESCRIPTION
As the title suggests, I found that when working on a project I needed to manipulate the bounds of a rectangle, so I thought this would be a neat addition to the library.

Now, given that this is actually my first contribution to an open source project, I have a feeling that I may not have done it entirely correctly. I read through the contribution guidelines but there are a few questions I still have, if I may ask here,

- Should I have created a separate branch for the feature or would the master branch be fine?
- I added the feature on a Windows machine, so when I went to test it, maven's checkstyle plugin kept complaining of the CRLF line endings. I was wondering if that would be an issue?

Thank you