### PR TITLE
Make Matrix4f.rotateXYZ able to take a Vector3fc

### DIFF
--- a/src/org/joml/Matrix4f.java
+++ b/src/org/joml/Matrix4f.java
@@ -5347,14 +5347,14 @@ public class Matrix4f implements Externalizable, Matrix4fc {
      * vector <code>v</code> with the new matrix by using <code>M * R * v</code>, the
      * rotation will be applied first!
      * <p>
-     * This method is equivalent to calling: <code>rotateX(angles.x).rotateY(angles.y).rotateZ(angles.z)</code>
+     * This method is equivalent to calling: <code>rotateX(angles.x()).rotateY(angles.y()).rotateZ(angles.z())</code>
      * 
      * @param angles
      *            the Euler angles
      * @return this
      */
-    public Matrix4f rotateXYZ(Vector3f angles) {
-        return rotateXYZ(angles.x, angles.y, angles.z);
+    public Matrix4f rotateXYZ(Vector3fc angles) {
+        return rotateXYZ(angles.x(), angles.y(), angles.z());
     }
 
     /**


### PR DESCRIPTION
There's no reason as to why this method needs to take a Vector3f, and not a Vector3fc.