### PR TITLE
Fix parameter ordering in Quaternion#rotateYXZ

### DIFF
--- a/src/org/joml/Quaterniond.java
+++ b/src/org/joml/Quaterniond.java
@@ -2734,8 +2734,8 @@ public class Quaterniond implements Externalizable, Quaterniondc {
      *              the angle in radians to rotate about the z axis
      * @return this
      */
-    public Quaterniond rotateYXZ(double angleZ, double angleY, double angleX) {
-        return rotateYXZ(angleZ, angleY, angleX, this);
+    public Quaterniond rotateYXZ(double angleY, double angleX, double angleZ) {
+        return rotateYXZ(angleY, angleX, angleZ, this);
     }
 
     public Quaterniond rotateYXZ(double angleY, double angleX, double angleZ, Quaterniond dest) {

--- a/src/org/joml/Quaternionf.java
+++ b/src/org/joml/Quaternionf.java
@@ -1825,8 +1825,8 @@ public class Quaternionf implements Externalizable, Quaternionfc {
      *              the angle in radians to rotate about the z axis
      * @return this
      */
-    public Quaternionf rotateYXZ(float angleZ, float angleY, float angleX) {
-        return rotateYXZ(angleZ, angleY, angleX, this);
+    public Quaternionf rotateYXZ(float angleY, float angleX, float angleZ) {
+        return rotateYXZ(angleY, angleX, angleZ, this);
     }
 
     public Quaternionf rotateYXZ(float angleY, float angleX, float angleZ, Quaternionf dest) {


### PR DESCRIPTION
This PR fixes the parameter ordering of the `rotateYXZ()` method in the Quaternion classes.