### PR TITLE
Add read-only interface AABBdi/f/d

### DIFF
--- a/src/org/joml/AABBd.java
+++ b/src/org/joml/AABBd.java
@@ -35,7 +35,7 @@ import java.text.NumberFormat;
  * 
  * @author Kai Burjack
  */
-public class AABBd implements Externalizable {
+public class AABBd implements Externalizable, AABBdc {
 
     /**
      * The x coordinate of the minimum corner.
@@ -75,13 +75,13 @@ public class AABBd implements Externalizable {
      * @param source
      *          the {@link AABBd} to copy from
      */
-    public AABBd(AABBd source) {
-        this.minX = source.minX;
-        this.minY = source.minY;
-        this.minZ = source.minZ;
-        this.maxX = source.maxX;
-        this.maxY = source.maxY;
-        this.maxZ = source.maxZ;
+    public AABBd(AABBdc source) {
+        this.minX = source.minX();
+        this.minY = source.minY();
+        this.minZ = source.minZ();
+        this.maxX = source.maxX();
+        this.maxY = source.maxY();
+        this.maxZ = source.maxZ();
     }
 
     /**
@@ -143,6 +143,30 @@ public class AABBd implements Externalizable {
         this.maxZ = maxZ;
     }
 
+    public double minX() {
+        return minX;
+    }
+
+    public double minY() {
+        return minY;
+    }
+
+    public double minZ() {
+        return minZ;
+    }
+
+    public double maxX() {
+        return maxX;
+    }
+
+    public double maxY() {
+        return maxY;
+    }
+
+    public double maxZ() {
+        return maxZ;
+    }
+
     /**
      * Set this {@link AABBd} to be a clone of <code>source</code>.
      *
@@ -150,13 +174,13 @@ public class AABBd implements Externalizable {
      *            the {@link AABBd} to copy from
      * @return this
      */
-    public AABBd set(AABBd source){
-        this.minX = source.minX;
-        this.minY = source.minY;
-        this.minZ = source.minZ;
-        this.maxX = source.maxX;
-        this.maxY = source.maxY;
-        this.maxZ = source.maxZ;
+    public AABBd set(AABBdc source){
+        this.minX = source.minX();
+        this.minY = source.minY();
+        this.minZ = source.minZ();
+        this.maxX = source.maxX();
+        this.maxY = source.maxY();
+        this.maxZ = source.maxZ();
         return this;
     }
 
@@ -173,11 +197,6 @@ public class AABBd implements Externalizable {
         return this;
     }
 
-    /**
-     * Check whether <code>this</code> AABB represents a valid AABB.
-     *
-     * @return <code>true</code> iff this AABB is valid; <code>false</code> otherwise
-     */
     public boolean isValid() {
         return minX < maxX && minY < maxY && minZ < maxZ;
     }
@@ -241,14 +260,6 @@ public class AABBd implements Externalizable {
         return this.setMax(max.x(), max.y(), max.z());
     }
 
-    /**
-     * Get the maximum corner coordinate of the given component.
-     * 
-     * @param component
-     *          the component, within <code>[0..2]</code>
-     * @return the maximum coordinate
-     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
-     */
     public double getMax(int component) throws IllegalArgumentException {
         switch (component) {
         case 0:
@@ -262,14 +273,6 @@ public class AABBd implements Externalizable {
         }
     }
 
-    /**
-     * Get the minimum corner coordinate of the given component.
-     * 
-     * @param component
-     *          the component, within <code>[0..2]</code>
-     * @return the maximum coordinate
-     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
-     */
     public double getMin(int component) throws IllegalArgumentException {
         switch (component) {
         case 0:
@@ -283,42 +286,18 @@ public class AABBd implements Externalizable {
         }
     }
 
-    /**
-     * Return the center of the aabb
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3d center(Vector3d dest) {
         return dest.set(minX + ((maxX - minX) / 2.0), minY + ((maxY - minY) / 2.0), minZ + ((maxZ - minZ) / 2.0));
     }
 
-    /**
-     * Return the center of the aabb
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3f center(Vector3f dest) {
         return dest.set(minX + ((maxX - minX) / 2.0f), minY + ((maxY - minY) / 2.0f), minZ + ((maxZ - minZ) / 2.0f));
     }
 
-    /**
-     * Extent of the aabb (max - min) / 2.0.
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3d extent(Vector3d dest) {
         return dest.set((maxX - minX) / 2.0, (maxY - minY) / 2.0, (maxZ - minZ) / 2.0);
     }
 
-    /**
-     * Extent of the aabb (max - min) / 2.0.
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3f extent(Vector3f dest) {
         return dest.set((maxX - minX) / 2.0f, (maxY - minY) / 2.0f, (maxZ - minZ) / 2.0f);
     }
@@ -349,19 +328,6 @@ public class AABBd implements Externalizable {
         return union(p.x(), p.y(), p.z(), this);
     }
 
-    /**
-     * Compute the union of <code>this</code> and the given point <code>(x, y, z)</code> and store the result in <code>dest</code>.
-     * 
-     * @param x
-     *          the x coordinate of the point
-     * @param y
-     *          the y coordinate of the point
-     * @param z
-     *          the z coordinate of the point
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBd union(double x, double y, double z, AABBd dest) {
         dest.minX = this.minX < x ? this.minX : x;
         dest.minY = this.minY < y ? this.minY : y;
@@ -372,15 +338,6 @@ public class AABBd implements Externalizable {
         return dest;
     }
 
-    /**
-     * Compute the union of <code>this</code> and the given point <code>p</code> and store the result in <code>dest</code>.
-     * 
-     * @param p
-     *          the point
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBd union(Vector3dc p, AABBd dest) {
         return union(p.x(), p.y(), p.z(), dest);
     }
@@ -392,26 +349,17 @@ public class AABBd implements Externalizable {
      *          the other {@link AABBd}
      * @return this
      */
-    public AABBd union(AABBd other) {
+    public AABBd union(AABBdc other) {
         return this.union(other, this);
     }
 
-    /**
-     * Compute the union of <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
-     * 
-     * @param other
-     *          the other {@link AABBd}
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
-    public AABBd union(AABBd other, AABBd dest) {
-        dest.minX = this.minX < other.minX ? this.minX : other.minX;
-        dest.minY = this.minY < other.minY ? this.minY : other.minY;
-        dest.minZ = this.minZ < other.minZ ? this.minZ : other.minZ;
-        dest.maxX = this.maxX > other.maxX ? this.maxX : other.maxX;
-        dest.maxY = this.maxY > other.maxY ? this.maxY : other.maxY;
-        dest.maxZ = this.maxZ > other.maxZ ? this.maxZ : other.maxZ;
+    public AABBd union(AABBdc other, AABBd dest) {
+        dest.minX = this.minX < other.minX() ? this.minX : other.minX();
+        dest.minY = this.minY < other.minY() ? this.minY : other.minY();
+        dest.minZ = this.minZ < other.minZ() ? this.minZ : other.minZ();
+        dest.maxX = this.maxX > other.maxX() ? this.maxX : other.maxX();
+        dest.maxY = this.maxY > other.maxY() ? this.maxY : other.maxY();
+        dest.maxZ = this.maxZ > other.maxZ() ? this.maxZ : other.maxZ();
         return dest;
     }
 
@@ -452,15 +400,6 @@ public class AABBd implements Externalizable {
         return translate(xyz.x(), xyz.y(), xyz.z(), this);
     }
 
-    /**
-     * Translate <code>this</code> by the given vector <code>xyz</code> and store the result in <code>dest</code>.
-     * 
-     * @param xyz
-     *          the vector to translate by
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBd translate(Vector3dc xyz, AABBd dest) {
         return translate(xyz.x(), xyz.y(), xyz.z(), dest);
     }
@@ -476,15 +415,6 @@ public class AABBd implements Externalizable {
         return translate(xyz.x(), xyz.y(), xyz.z(), this);
     }
 
-    /**
-     * Translate <code>this</code> by the given vector <code>xyz</code> and store the result in <code>dest</code>.
-     * 
-     * @param xyz
-     *          the vector to translate by
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBd translate(Vector3fc xyz, AABBd dest) {
         return translate(xyz.x(), xyz.y(), xyz.z(), dest);
     }
@@ -504,19 +434,6 @@ public class AABBd implements Externalizable {
         return translate(x, y, z, this);
     }
 
-    /**
-     * Translate <code>this</code> by the vector <code>(x, y, z)</code> and store the result in <code>dest</code>.
-     * 
-     * @param x
-     *          the x coordinate to translate by
-     * @param y
-     *          the y coordinate to translate by
-     * @param z
-     *          the z coordinate to translate by
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBd translate(double x, double y, double z, AABBd dest) {
         dest.minX = minX + x;
         dest.minY = minY + y;
@@ -527,31 +444,16 @@ public class AABBd implements Externalizable {
         return dest;
     }
 
+    public AABBd intersection(AABBdc other, AABBd dest) {
+        dest.minX = Math.max(minX, other.minX());
+        dest.minY = Math.max(minY, other.minY());
+        dest.minZ = Math.max(minZ, other.minZ());
 
-    /**
-     * Compute the AABB of intersection between <code>this</code> and the given AABB.
-     * <p>
-     * If the two AABBs do not intersect, then the minimum coordinates of <code>this</code>
-     * will have a value of {@link Double#POSITIVE_INFINITY} and the maximum coordinates will have a value of
-     * {@link Double#NEGATIVE_INFINITY}.
-     *
-     * @param other
-     *           the other AABB
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
-    public AABBd intersection(AABBd other, AABBd dest) {
-        dest.minX = Math.max(minX, other.minX);
-        dest.minY = Math.max(minY, other.minY);
-        dest.minZ = Math.max(minZ, other.minZ);
-
-        dest.maxX = Math.min(maxX, other.maxX);
-        dest.maxY = Math.min(maxY, other.maxY);
-        dest.maxZ = Math.min(maxZ, other.maxZ);
+        dest.maxX = Math.min(maxX, other.maxX());
+        dest.maxY = Math.min(maxY, other.maxY());
+        dest.maxZ = Math.min(maxZ, other.maxZ());
         return dest.validate();
     }
-
 
     /**
      * Compute the AABB of intersection between <code>this</code> and the given AABB.
@@ -564,298 +466,77 @@ public class AABBd implements Externalizable {
      *           the other AABB
      * @return this
      */
-    public AABBd intersection(AABBd other) {
+    public AABBd intersection(AABBdc other) {
         return intersection(other, this);
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBd aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBdc aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBf aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBfc aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBi aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBic aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-
-    /**
-     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
-     *
-     * @param x
-     *          the x coordinate of the point
-     * @param y
-     *          the y coordinate of the point
-     * @param z
-     *          the z coordinate of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(double x, double y, double z) {
         return x >= minX && y >= minY && z >= minZ && x <= maxX && y <= maxY && z <= maxZ;
     }
 
-    /**
-     * Test whether the given point lies inside this AABB.
-     *
-     * @param point
-     *          the coordinates of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(Vector3dc point) {
         return containsPoint(point.x(), point.y(), point.z());
     }
 
-    /**
-     * Test whether the plane given via its plane equation <code>a*x + b*y + c*z + d = 0</code> intersects this AABB.
-     * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
-     *
-     * @param a
-     *          the x factor in the plane equation
-     * @param b
-     *          the y factor in the plane equation
-     * @param c
-     *          the z factor in the plane equation
-     * @param d
-     *          the constant in the plane equation
-     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsPlane(double a, double b, double c, double d) {
         return Intersectiond.testAabPlane(minX, minY, minZ, maxX, maxY, maxZ, a, b, c, d);
     }
 
-    /**
-     * Test whether the given plane intersects this AABB.
-     * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
-     *
-     * @param plane
-     *          the plane
-     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsPlane(Planed plane) {
         return Intersectiond.testAabPlane(this, plane);
     }
 
-    /**
-     * Test whether <code>this</code> and <code>other</code> intersect.
-     *
-     * @param other
-     *          the other AABB
-     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
-     */
     public boolean intersectsAABB(AABBd other) {
         return this.maxX >= other.minX && this.maxY >= other.minY && this.maxZ >= other.minZ &&
                this.minX <= other.maxX && this.minY <= other.maxY && this.minZ <= other.maxZ;
     }
 
-    /**
-     * Test whether this AABB intersects the given sphere with equation
-     * <code>(x - centerX)^2 + (y - centerY)^2 + (z - centerZ)^2 - radiusSquared = 0</code>.
-     * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
-     * 
-     * @param centerX
-     *          the x coordinate of the center of the sphere
-     * @param centerY
-     *          the y coordinate of the center of the sphere
-     * @param centerZ
-     *          the z coordinate of the center of the sphere
-     * @param radiusSquared
-     *          the square radius of the sphere
-     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
-     */
     public boolean intersectsSphere(double centerX, double centerY, double centerZ, double radiusSquared) {
         return Intersectiond.testAabSphere(minX, minY, minZ, maxX, maxY, maxZ, centerX, centerY, centerZ, radiusSquared);
     }
 
-    /**
-     * Test whether this AABB intersects the given sphere.
-     * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
-     *
-     * @param sphere
-     *          the sphere
-     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
-     */
     public boolean intersectsSphere(Spheref sphere) {
         return Intersectiond.testAabSphere(this, sphere);
     }
 
-    /**
-     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
-     * intersects this AABB.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param originX
-     *          the x coordinate of the ray's origin
-     * @param originY
-     *          the y coordinate of the ray's origin
-     * @param originZ
-     *          the z coordinate of the ray's origin
-     * @param dirX
-     *          the x coordinate of the ray's direction
-     * @param dirY
-     *          the y coordinate of the ray's direction
-     * @param dirZ
-     *          the z coordinate of the ray's direction
-     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
-     */
     public boolean intersectsRay(double originX, double originY, double originZ, double dirX, double dirY, double dirZ) {
         return Intersectiond.testRayAab(originX, originY, originZ, dirX, dirY, dirZ, minX, minY, minZ, maxX, maxY, maxZ);
     }
 
-    /**
-     * Test whether the given ray intersects this AABB.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     *
-     * @param ray
-     *          the ray
-     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
-     */
     public boolean intersectsRay(Rayd ray) {
         return Intersectiond.testRayAab(ray, this);
     }
 
-    /**
-     * Determine whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
-     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param originX
-     *              the x coordinate of the ray's origin
-     * @param originY
-     *              the y coordinate of the ray's origin
-     * @param originZ
-     *              the z coordinate of the ray's origin
-     * @param dirX
-     *              the x coordinate of the ray's direction
-     * @param dirY
-     *              the y coordinate of the ray's direction
-     * @param dirZ
-     *              the z coordinate of the ray's direction
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
-     *              iff the ray intersects this AABB
-     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsRay(double originX, double originY, double originZ, double dirX, double dirY, double dirZ, Vector2d result) {
         return Intersectiond.intersectRayAab(originX, originY, originZ, dirX, dirY, dirZ, minX, minY, minZ, maxX, maxY, maxZ, result);
     }
 
-    /**
-     * Determine whether the given ray intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param ray
-     *              the ray
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
-     *              iff the ray intersects this AABB
-     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsRay(Rayd ray, Vector2d result) {
         return Intersectiond.intersectRayAab(ray, this, result);
     }
 
-    /**
-     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X, p1Y, p1Z)</code>
-     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param p0X
-     *              the x coordinate of the line segment's first end point
-     * @param p0Y
-     *              the y coordinate of the line segment's first end point
-     * @param p0Z
-     *              the z coordinate of the line segment's first end point
-     * @param p1X
-     *              the x coordinate of the line segment's second end point
-     * @param p1Y
-     *              the y coordinate of the line segment's second end point
-     * @param p1Z
-     *              the z coordinate of the line segment's second end point
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectiond#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectiond#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectiond#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectiond#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
-     */
     public int intersectsLineSegment(double p0X, double p0Y, double p0Z, double p1X, double p1Y, double p1Z, Vector2d result) {
         return Intersectiond.intersectLineSegmentAab(p0X, p0Y, p0Z, p1X, p1Y, p1Z, minX, minY, minZ, maxX, maxY, maxZ, result);
     }
 
-    /**
-     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param lineSegment
-     *              the line segment
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectiond#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectiond#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectiond#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectiond#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
-     */
     public int intersectsLineSegment(LineSegmentf lineSegment, Vector2d result) {
         return Intersectiond.intersectLineSegmentAab(lineSegment, this, result);
     }
@@ -864,7 +545,7 @@ public class AABBd implements Externalizable {
      * Apply the given {@link Matrix4dc#isAffine() affine} transformation to this {@link AABBd}.
      * <p>
      * The matrix in <code>m</code> <i>must</i> be {@link Matrix4dc#isAffine() affine}.
-     * 
+     *
      * @param m
      *          the affine transformation matrix
      * @return this
@@ -873,18 +554,6 @@ public class AABBd implements Externalizable {
         return transform(m, this);
     }
 
-    /**
-     * Apply the given {@link Matrix4dc#isAffine() affine} transformation to this {@link AABBd}
-     * and store the resulting AABB into <code>dest</code>.
-     * <p>
-     * The matrix in <code>m</code> <i>must</i> be {@link Matrix4dc#isAffine() affine}.
-     * 
-     * @param m
-     *          the affine transformation matrix
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBd transform(Matrix4dc m, AABBd dest) {
         double dx = maxX - minX, dy = maxY - minY, dz = maxZ - minZ;
         double minx = Double.POSITIVE_INFINITY, miny = Double.POSITIVE_INFINITY, minz = Double.POSITIVE_INFINITY;

--- a/src/org/joml/AABBdc.java
+++ b/src/org/joml/AABBdc.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2020 JOML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.joml;
 
 public interface AABBdc {

--- a/src/org/joml/AABBdc.java
+++ b/src/org/joml/AABBdc.java
@@ -1,0 +1,462 @@
+package org.joml;
+
+public interface AABBdc {
+
+    /**
+     * @return The x coordinate of the minimum corner.
+     */
+    double minX();
+
+    /**
+     * @return The y coordinate of the minimum corner.
+     */
+    double minY();
+
+    /**
+     * @return The z coordinate of the minimum corner.
+     */
+    double minZ();
+
+    /**
+     * @return The x coordinate of the maximum corner.
+     */
+    double maxX();
+
+    /**
+     * @return The y coordinate of the maximum corner.
+     */
+    double maxY();
+
+    /**
+     * @return The z coordinate of the maximum corner.
+     */
+    double maxZ();
+
+    /**
+     * Check whether <code>this</code> AABB represents a valid AABB.
+     *
+     * @return <code>true</code> iff this AABB is valid; <code>false</code> otherwise
+     */
+    boolean isValid();
+
+    /**
+     * Get the maximum corner coordinate of the given component.
+     *
+     * @param component
+     *          the component, within <code>[0..2]</code>
+     * @return the maximum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
+     */
+    double getMax(int component);
+
+    /**
+     * Get the minimum corner coordinate of the given component.
+     *
+     * @param component
+     *          the component, within <code>[0..2]</code>
+     * @return the maximum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
+     */
+    double getMin(int component);
+
+    /**
+     * Return the center of the aabb
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3d center(Vector3d dest);
+
+    /**
+     * Return the center of the aabb
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3f center(Vector3f dest);
+
+    /**
+     * Extent of the aabb (max - min) / 2.0.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3d extent(Vector3d dest);
+
+    /**
+     * Extent of the aabb (max - min) / 2.0.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3f extent(Vector3f dest);
+
+    /**
+     * Compute the union of <code>this</code> and the given point <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     *
+     * @param x
+     *          the x coordinate of the point
+     * @param y
+     *          the y coordinate of the point
+     * @param z
+     *          the z coordinate of the point
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd union(double x, double y, double z, AABBd dest);
+
+
+    /**
+     * Compute the union of <code>this</code> and the given point <code>p</code> and store the result in <code>dest</code>.
+     *
+     * @param p
+     *          the point
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd union(Vector3dc p, AABBd dest);
+
+
+    /**
+     * Compute the union of <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
+     *
+     * @param other
+     *          the other {@link AABBd}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd union(AABBdc other, AABBd dest);
+
+    /**
+     * Translate <code>this</code> by the given vector <code>xyz</code> and store the result in <code>dest</code>.
+     *
+     * @param xyz
+     *          the vector to translate by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd translate(Vector3dc xyz, AABBd dest);
+
+
+    /**
+     * Translate <code>this</code> by the given vector <code>xyz</code> and store the result in <code>dest</code>.
+     *
+     * @param xyz
+     *          the vector to translate by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd translate(Vector3fc xyz, AABBd dest);
+
+    /**
+     * Translate <code>this</code> by the vector <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     *
+     * @param x
+     *          the x coordinate to translate by
+     * @param y
+     *          the y coordinate to translate by
+     * @param z
+     *          the z coordinate to translate by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd translate(double x, double y, double z, AABBd dest);
+
+
+    /**
+     * Compute the AABB of intersection between <code>this</code> and the given AABB.
+     * <p>
+     * If the two AABBs do not intersect, then the minimum coordinates of <code>this</code>
+     * will have a value of {@link Double#POSITIVE_INFINITY} and the maximum coordinates will have a value of
+     * {@link Double#NEGATIVE_INFINITY}.
+     *
+     * @param other
+     *           the other AABB
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd intersection(AABBdc other, AABBd dest);
+
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBdc aabb);
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBfc aabb);
+
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBic aabb);
+
+
+    /**
+     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
+     *
+     * @param x
+     *          the x coordinate of the point
+     * @param y
+     *          the y coordinate of the point
+     * @param z
+     *          the z coordinate of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(double x, double y, double z);
+
+
+    /**
+     * Test whether the given point lies inside this AABB.
+     *
+     * @param point
+     *          the coordinates of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(Vector3dc point);
+
+    /**
+     * Test whether the plane given via its plane equation <code>a*x + b*y + c*z + d = 0</code> intersects this AABB.
+     * <p>
+     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     *
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsPlane(double a, double b, double c, double d);
+
+
+    /**
+     * Test whether the given plane intersects this AABB.
+     * <p>
+     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     *
+     * @param plane
+     *          the plane
+     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsPlane(Planed plane);
+
+
+    /**
+     * Test whether <code>this</code> and <code>other</code> intersect.
+     *
+     * @param other
+     *          the other AABB
+     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
+     */
+    boolean intersectsAABB(AABBd other);
+
+    /**
+     * Test whether this AABB intersects the given sphere with equation
+     * <code>(x - centerX)^2 + (y - centerY)^2 + (z - centerZ)^2 - radiusSquared = 0</code>.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     *
+     * @param centerX
+     *          the x coordinate of the center of the sphere
+     * @param centerY
+     *          the y coordinate of the center of the sphere
+     * @param centerZ
+     *          the z coordinate of the center of the sphere
+     * @param radiusSquared
+     *          the square radius of the sphere
+     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
+     */
+    boolean intersectsSphere(double centerX, double centerY, double centerZ, double radiusSquared) ;
+
+    /**
+     * Test whether this AABB intersects the given sphere.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     *
+     * @param sphere
+     *          the sphere
+     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
+     */
+    boolean intersectsSphere(Spheref sphere);
+
+
+    /**
+     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
+     * intersects this AABB.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param originX
+     *          the x coordinate of the ray's origin
+     * @param originY
+     *          the y coordinate of the ray's origin
+     * @param originZ
+     *          the z coordinate of the ray's origin
+     * @param dirX
+     *          the x coordinate of the ray's direction
+     * @param dirY
+     *          the y coordinate of the ray's direction
+     * @param dirZ
+     *          the z coordinate of the ray's direction
+     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
+     */
+    boolean intersectsRay(double originX, double originY, double originZ, double dirX, double dirY, double dirZ) ;
+
+
+
+    /**
+     * Test whether the given ray intersects this AABB.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param ray
+     *          the ray
+     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
+     */
+    boolean intersectsRay(Rayd ray);
+    /**
+     * Determine whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
+     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param originX
+     *              the x coordinate of the ray's origin
+     * @param originY
+     *              the y coordinate of the ray's origin
+     * @param originZ
+     *              the z coordinate of the ray's origin
+     * @param dirX
+     *              the x coordinate of the ray's direction
+     * @param dirY
+     *              the y coordinate of the ray's direction
+     * @param dirZ
+     *              the z coordinate of the ray's direction
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
+     *              iff the ray intersects this AABB
+     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsRay(double originX, double originY, double originZ, double dirX, double dirY, double dirZ, Vector2d result);
+
+
+    /**
+     * Determine whether the given ray intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param ray
+     *              the ray
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
+     *              iff the ray intersects this AABB
+     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsRay(Rayd ray, Vector2d result);
+
+    /**
+     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X, p1Y, p1Z)</code>
+     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param p0X
+     *              the x coordinate of the line segment's first end point
+     * @param p0Y
+     *              the y coordinate of the line segment's first end point
+     * @param p0Z
+     *              the z coordinate of the line segment's first end point
+     * @param p1X
+     *              the x coordinate of the line segment's second end point
+     * @param p1Y
+     *              the y coordinate of the line segment's second end point
+     * @param p1Z
+     *              the z coordinate of the line segment's second end point
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *              iff the line segment intersects this AABB
+     * @return {@link Intersectiond#INSIDE} if the line segment lies completely inside of this AABB; or
+     *         {@link Intersectiond#OUTSIDE} if the line segment lies completely outside of this AABB; or
+     *         {@link Intersectiond#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectiond#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     */
+    int intersectsLineSegment(double p0X, double p0Y, double p0Z, double p1X, double p1Y, double p1Z, Vector2d result) ;
+
+    /**
+     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param lineSegment
+     *              the line segment
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *              iff the line segment intersects this AABB
+     * @return {@link Intersectiond#INSIDE} if the line segment lies completely inside of this AABB; or
+     *         {@link Intersectiond#OUTSIDE} if the line segment lies completely outside of this AABB; or
+     *         {@link Intersectiond#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectiond#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     */
+    int intersectsLineSegment(LineSegmentf lineSegment, Vector2d result);
+
+    /**
+     * Apply the given {@link Matrix4dc#isAffine() affine} transformation to this {@link AABBd}
+     * and store the resulting AABB into <code>dest</code>.
+     * <p>
+     * The matrix in <code>m</code> <i>must</i> be {@link Matrix4dc#isAffine() affine}.
+     *
+     * @param m
+     *          the affine transformation matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBd transform(Matrix4dc m, AABBd dest);
+
+}

--- a/src/org/joml/AABBdc.java
+++ b/src/org/joml/AABBdc.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017-2020 JOML
+ * Copyright (c) 2020 JOML
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,9 @@
  */
 package org.joml;
 
+/**
+ * Interface to a read-only view of a AABB of double-precision floats
+ */
 public interface AABBdc {
 
     /**

--- a/src/org/joml/AABBf.java
+++ b/src/org/joml/AABBf.java
@@ -35,7 +35,7 @@ import java.text.NumberFormat;
  * 
  * @author Kai Burjack
  */
-public class AABBf implements Externalizable {
+public class AABBf implements Externalizable, AABBfc {
 
     /**
      * The x coordinate of the minimum corner.
@@ -133,13 +133,13 @@ public class AABBf implements Externalizable {
      *            the {@link AABBf} to copy from
      * @return this
      */
-    public AABBf set(AABBf source){
-        this.minX = source.minX;
-        this.minY = source.minY;
-        this.minZ = source.minZ;
-        this.maxX = source.maxX;
-        this.maxY = source.maxY;
-        this.maxZ = source.maxZ;
+    public AABBf set(AABBfc source){
+        this.minX = source.minX();
+        this.minY = source.minY();
+        this.minZ = source.minZ();
+        this.maxX = source.maxX();
+        this.maxY = source.maxY();
+        this.maxZ = source.maxZ();
         return this;
     }
 
@@ -156,15 +156,33 @@ public class AABBf implements Externalizable {
         return this;
     }
 
-    /**
-     * Check whether <code>this</code> rectangle represents a valid AABB.
-     *
-     * @return <code>true</code> iff this rectangle is valid; <code>false</code> otherwise
-     */
+    public float minX() {
+        return minX;
+    }
+
+    public float minY() {
+        return minY;
+    }
+
+    public float minZ() {
+        return minZ;
+    }
+
+    public float maxX() {
+        return maxX;
+    }
+
+    public float maxY() {
+        return maxY;
+    }
+
+    public float maxZ() {
+        return maxZ;
+    }
+
     public boolean isValid() {
         return minX < maxX && minY < maxY && minZ < maxZ;
     }
-
 
     /**
      * Set the minimum corner coordinates.
@@ -224,14 +242,6 @@ public class AABBf implements Externalizable {
         return this.setMax(max.x(), max.y(), max.z());
     }
 
-    /**
-     * Get the maximum corner coordinate of the given component.
-     * 
-     * @param component
-     *          the component, within <code>[0..2]</code>
-     * @return the maximum coordinate
-     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
-     */
     public float getMax(int component) throws IllegalArgumentException {
         switch (component) {
         case 0:
@@ -245,14 +255,6 @@ public class AABBf implements Externalizable {
         }
     }
 
-    /**
-     * Get the minimum corner coordinate of the given component.
-     * 
-     * @param component
-     *          the component, within <code>[0..2]</code>
-     * @return the maximum coordinate
-     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
-     */
     public float getMin(int component) throws IllegalArgumentException {
         switch (component) {
         case 0:
@@ -266,42 +268,18 @@ public class AABBf implements Externalizable {
         }
     }
 
-    /**
-     * Return the center of the aabb
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3f center(Vector3f dest) {
         return dest.set(minX + ((maxX - minX) / 2.0f), minY + ((maxY - minY) / 2.0f), minZ + ((maxZ - minZ) / 2.0f));
     }
 
-    /**
-     * Return the center of the aabb
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3d center(Vector3d dest) {
         return dest.set(minX + ((maxX - minX) / 2.0), minY + ((maxY - minY) / 2.0), minZ + ((maxZ - minZ) / 2.0));
     }
 
-    /**
-     * Extent of the aabb (max - min) / 2.0.
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3d extent(Vector3d dest) {
         return dest.set((maxX - minX) / 2.0, (maxY - minY) / 2.0, (maxZ - minZ) / 2.0);
     }
 
-    /**
-     * Extent of the aabb (max - min) / 2.0.
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3f extent(Vector3f dest) {
         return dest.set((maxX - minX) / 2.0f, (maxY - minY) / 2.0f, (maxZ - minZ) / 2.0f);
     }
@@ -332,19 +310,6 @@ public class AABBf implements Externalizable {
         return union(p.x(), p.y(), p.z(), this);
     }
 
-    /**
-     * Compute the union of <code>this</code> and the given point <code>(x, y, z)</code> and store the result in <code>dest</code>.
-     * 
-     * @param x
-     *          the x coordinate of the point
-     * @param y
-     *          the y coordinate of the point
-     * @param z
-     *          the z coordinate of the point
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBf union(float x, float y, float z, AABBf dest) {
         dest.minX = this.minX < x ? this.minX : x;
         dest.minY = this.minY < y ? this.minY : y;
@@ -355,15 +320,6 @@ public class AABBf implements Externalizable {
         return dest;
     }
 
-    /**
-     * Compute the union of <code>this</code> and the given point <code>p</code> and store the result in <code>dest</code>.
-     * 
-     * @param p
-     *          the point
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBf union(Vector3fc p, AABBf dest) {
         return union(p.x(), p.y(), p.z(), dest);
     }
@@ -379,15 +335,6 @@ public class AABBf implements Externalizable {
         return this.union(other, this);
     }
 
-    /**
-     * Compute the union of <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
-     * 
-     * @param other
-     *          the other {@link AABBf}
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBf union(AABBf other, AABBf dest) {
         dest.minX = this.minX < other.minX ? this.minX : other.minX;
         dest.minY = this.minY < other.minY ? this.minY : other.minY;
@@ -435,15 +382,6 @@ public class AABBf implements Externalizable {
         return translate(xyz.x(), xyz.y(), xyz.z(), this);
     }
 
-    /**
-     * Translate <code>this</code> by the given vector <code>xyz</code> and store the result in <code>dest</code>.
-     * 
-     * @param xyz
-     *          the vector to translate by
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBf translate(Vector3fc xyz, AABBf dest) {
         return translate(xyz.x(), xyz.y(), xyz.z(), dest);
     }
@@ -463,19 +401,6 @@ public class AABBf implements Externalizable {
         return translate(x, y, z, this);
     }
 
-    /**
-     * Translate <code>this</code> by the vector <code>(x, y, z)</code> and store the result in <code>dest</code>.
-     * 
-     * @param x
-     *          the x coordinate to translate by
-     * @param y
-     *          the y coordinate to translate by
-     * @param z
-     *          the z coordinate to translate by
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBf translate(float x, float y, float z, AABBf dest) {
         dest.minX = minX + x;
         dest.minY = minY + y;
@@ -486,30 +411,16 @@ public class AABBf implements Externalizable {
         return dest;
     }
 
-    /**
-     * Compute the AABB of intersection between <code>this</code> and the given AABB.
-     * <p>
-     * If the two AABBs do not intersect, then the minimum coordinates of <code>this</code>
-     * will have a value of {@link Float#POSITIVE_INFINITY} and the maximum coordinates will have a value of
-     * {@link Float#NEGATIVE_INFINITY}.
-     *
-     * @param other
-     *           the other AABB
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
-    public AABBf intersection(AABBf other, AABBf dest) {
-        dest.minX = Math.max(minX, other.minX);
-        dest.minY = Math.max(minY, other.minY);
-        dest.minZ = Math.max(minZ, other.minZ);
+    public AABBf intersection(AABBfc other, AABBf dest) {
+        dest.minX = Math.max(minX, other.minX());
+        dest.minY = Math.max(minY, other.minY());
+        dest.minZ = Math.max(minZ, other.minZ());
 
-        dest.maxX = Math.min(maxX, other.maxX);
-        dest.maxY = Math.min(maxY, other.maxY);
-        dest.maxZ = Math.min(maxZ, other.maxZ);
+        dest.maxX = Math.min(maxX, other.maxX());
+        dest.maxY = Math.min(maxY, other.maxY());
+        dest.maxZ = Math.min(maxZ, other.maxZ());
         return dest.validate();
     }
-
 
     /**
      * Compute the AABB of intersection between <code>this</code> and the given AABB.
@@ -522,298 +433,77 @@ public class AABBf implements Externalizable {
      *           the other AABB
      * @return this
      */
-    public AABBf intersection(AABBf other) {
+    public AABBf intersection(AABBfc other) {
         return intersection(other, this);
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBd aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBdc aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBf aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBfc aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBi aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBic aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-
-    /**
-     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
-     * 
-     * @param x
-     *          the x coordinate of the point
-     * @param y
-     *          the y coordinate of the point
-     * @param z
-     *          the z coordinate of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(float x, float y, float z) {
         return x >= minX && y >= minY && z >= minZ && x <= maxX && y <= maxY && z <= maxZ;
     }
 
-    /**
-     * Test whether the given point lies inside this AABB.
-     * 
-     * @param point
-     *          the coordinates of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(Vector3fc point) {
         return containsPoint(point.x(), point.y(), point.z());
     }
 
-    /**
-     * Test whether the plane given via its plane equation <code>a*x + b*y + c*z + d = 0</code> intersects this AABB.
-     * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
-     * 
-     * @param a
-     *          the x factor in the plane equation
-     * @param b
-     *          the y factor in the plane equation
-     * @param c
-     *          the z factor in the plane equation
-     * @param d
-     *          the constant in the plane equation
-     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsPlane(float a, float b, float c, float d) {
         return Intersectionf.testAabPlane(minX, minY, minZ, maxX, maxY, maxZ, a, b, c, d);
     }
 
-    /**
-     * Test whether the given plane intersects this AABB.
-     * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
-     * 
-     * @param plane
-     *          the plane
-     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsPlane(Planef plane) {
         return Intersectionf.testAabPlane(this, plane);
     }
 
-    /**
-     * Test whether <code>this</code> and <code>other</code> intersect.
-     * 
-     * @param other
-     *          the other AABB
-     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
-     */
-    public boolean intersectsAABB(AABBf other) {
-        return this.maxX >= other.minX && this.maxY >= other.minY && this.maxZ >= other.minZ &&
-               this.minX <= other.maxX && this.minY <= other.maxY && this.minZ <= other.maxZ;
+    public boolean intersectsAABB(AABBfc other) {
+        return this.maxX >= other.minX() && this.maxY >= other.minY() && this.maxZ >= other.minZ() &&
+               this.minX <= other.maxX() && this.minY <= other.maxY() && this.minZ <= other.maxZ();
     }
 
-    /**
-     * Test whether this AABB intersects the given sphere with equation
-     * <code>(x - centerX)^2 + (y - centerY)^2 + (z - centerZ)^2 - radiusSquared = 0</code>.
-     * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
-     * 
-     * @param centerX
-     *          the x coordinate of the center of the sphere
-     * @param centerY
-     *          the y coordinate of the center of the sphere
-     * @param centerZ
-     *          the z coordinate of the center of the sphere
-     * @param radiusSquared
-     *          the square radius of the sphere
-     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
-     */
     public boolean intersectsSphere(float centerX, float centerY, float centerZ, float radiusSquared) {
         return Intersectionf.testAabSphere(minX, minY, minZ, maxX, maxY, maxZ, centerX, centerY, centerZ, radiusSquared);
     }
 
-    /**
-     * Test whether this AABB intersects the given sphere.
-     * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
-     * 
-     * @param sphere
-     *          the sphere
-     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
-     */
     public boolean intersectsSphere(Spheref sphere) {
         return Intersectionf.testAabSphere(this, sphere);
     }
 
-    /**
-     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
-     * intersects this AABB.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param originX
-     *          the x coordinate of the ray's origin
-     * @param originY
-     *          the y coordinate of the ray's origin
-     * @param originZ
-     *          the z coordinate of the ray's origin
-     * @param dirX
-     *          the x coordinate of the ray's direction
-     * @param dirY
-     *          the y coordinate of the ray's direction
-     * @param dirZ
-     *          the z coordinate of the ray's direction
-     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
-     */
     public boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ) {
         return Intersectionf.testRayAab(originX, originY, originZ, dirX, dirY, dirZ, minX, minY, minZ, maxX, maxY, maxZ);
     }
 
-    /**
-     * Test whether the given ray intersects this AABB.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param ray
-     *          the ray
-     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
-     */
     public boolean intersectsRay(Rayf ray) {
         return Intersectionf.testRayAab(ray, this);
     }
 
-    /**
-     * Determine whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
-     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param originX
-     *              the x coordinate of the ray's origin
-     * @param originY
-     *              the y coordinate of the ray's origin
-     * @param originZ
-     *              the z coordinate of the ray's origin
-     * @param dirX
-     *              the x coordinate of the ray's direction
-     * @param dirY
-     *              the y coordinate of the ray's direction
-     * @param dirZ
-     *              the z coordinate of the ray's direction
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
-     *              iff the ray intersects this AABB
-     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ, Vector2f result) {
         return Intersectionf.intersectRayAab(originX, originY, originZ, dirX, dirY, dirZ, minX, minY, minZ, maxX, maxY, maxZ, result);
     }
 
-    /**
-     * Determine whether the given ray intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param ray
-     *              the ray
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
-     *              iff the ray intersects this AABB
-     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsRay(Rayf ray, Vector2f result) {
         return Intersectionf.intersectRayAab(ray, this, result);
     }
 
-    /**
-     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X, p1Y, p1Z)</code>
-     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param p0X
-     *              the x coordinate of the line segment's first end point
-     * @param p0Y
-     *              the y coordinate of the line segment's first end point
-     * @param p0Z
-     *              the z coordinate of the line segment's first end point
-     * @param p1X
-     *              the x coordinate of the line segment's second end point
-     * @param p1Y
-     *              the y coordinate of the line segment's second end point
-     * @param p1Z
-     *              the z coordinate of the line segment's second end point
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
-     */
     public int intersectsLineSegment(float p0X, float p0Y, float p0Z, float p1X, float p1Y, float p1Z, Vector2f result) {
         return Intersectionf.intersectLineSegmentAab(p0X, p0Y, p0Z, p1X, p1Y, p1Z, minX, minY, minZ, maxX, maxY, maxZ, result);
     }
 
-    /**
-     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     * 
-     * @param lineSegment
-     *              the line segment
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
-     */
     public int intersectsLineSegment(LineSegmentf lineSegment, Vector2f result) {
         return Intersectionf.intersectLineSegmentAab(lineSegment, this, result);
     }
@@ -831,18 +521,6 @@ public class AABBf implements Externalizable {
         return transform(m, this);
     }
 
-    /**
-     * Apply the given {@link Matrix4fc#isAffine() affine} transformation to this
-     * {@link AABBf} and store the resulting AABB into <code>dest</code>.
-     * <p>
-     * The matrix in <code>m</code> <i>must</i> be {@link Matrix4fc#isAffine() affine}.
-     * 
-     * @param m
-     *          the affine transformation matrix
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBf transform(Matrix4fc m, AABBf dest) {
         float dx = maxX - minX, dy = maxY - minY, dz = maxZ - minZ;
         float minx = Float.POSITIVE_INFINITY, miny = Float.POSITIVE_INFINITY, minz = Float.POSITIVE_INFINITY;
@@ -914,13 +592,6 @@ public class AABBf implements Externalizable {
         return Runtime.formatNumbers(toString(Options.NUMBER_FORMAT));
     }
 
-    /**
-     * Return a string representation of this AABB by formatting the vector components with the given {@link NumberFormat}.
-     * 
-     * @param formatter
-     *          the {@link NumberFormat} used to format the vector components with
-     * @return the string representation
-     */
     public String toString(NumberFormat formatter) {
         return "(" + Runtime.format(minX, formatter) + " " + Runtime.format(minY, formatter) + " " + Runtime.format(minZ, formatter) + ") < "
              + "(" + Runtime.format(maxX, formatter) + " " + Runtime.format(maxY, formatter) + " " + Runtime.format(maxZ, formatter) + ")";

--- a/src/org/joml/AABBfc.java
+++ b/src/org/joml/AABBfc.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017-2020 JOML
+ * Copyright (c) 2020 JOML
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,9 @@ package org.joml;
 
 import java.text.NumberFormat;
 
+/**
+ * Interface to a read-only view of a AABB of floats
+ */
 public interface AABBfc {
 
     /**

--- a/src/org/joml/AABBfc.java
+++ b/src/org/joml/AABBfc.java
@@ -1,0 +1,451 @@
+package org.joml;
+
+import java.text.NumberFormat;
+
+public interface AABBfc {
+
+    /**
+     * @return The x coordinate of the minimum corner.
+     */
+    float minX();
+
+    /**
+     * @return The y coordinate of the minimum corner.
+     */
+    float minY();
+
+    /**
+     * @return The z coordinate of the minimum corner.
+     */
+    float minZ();
+
+    /**
+     * @return The x coordinate of the maximum corner.
+     */
+    float maxX();
+
+    /**
+     * @return The y coordinate of the maximum corner.
+     */
+    float maxY();
+
+    /**
+     * @return The z coordinate of the maximum corner.
+     */
+    float maxZ();
+
+    /**
+     * Check whether <code>this</code> rectangle represents a valid AABB.
+     *
+     * @return <code>true</code> iff this rectangle is valid; <code>false</code> otherwise
+     */
+    boolean isValid();
+
+    /**
+     * Get the maximum corner coordinate of the given component.
+     *
+     * @param component
+     *          the component, within <code>[0..2]</code>
+     * @return the maximum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
+     */
+    float getMax(int component);
+
+    /**
+     * Get the minimum corner coordinate of the given component.
+     *
+     * @param component
+     *          the component, within <code>[0..2]</code>
+     * @return the maximum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
+     */
+    float getMin(int component);
+
+    /**
+     * Return the center of the aabb
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3f center(Vector3f dest);
+
+    /**
+     * Return the center of the aabb
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3d center(Vector3d dest);
+
+    /**
+     * Extent of the aabb (max - min) / 2.0.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3d extent(Vector3d dest);
+
+    /**
+     * Extent of the aabb (max - min) / 2.0.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3f extent(Vector3f dest);
+
+    /**
+     * Compute the union of <code>this</code> and the given point <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     *
+     * @param x
+     *          the x coordinate of the point
+     * @param y
+     *          the y coordinate of the point
+     * @param z
+     *          the z coordinate of the point
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBf union(float x, float y, float z, AABBf dest);
+
+    /**
+     * Compute the union of <code>this</code> and the given point <code>p</code> and store the result in <code>dest</code>.
+     *
+     * @param p
+     *          the point
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBf union(Vector3fc p, AABBf dest);
+
+    /**
+     * Compute the union of <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
+     *
+     * @param other
+     *          the other {@link AABBf}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBf union(AABBf other, AABBf dest);
+
+    /**
+     * Translate <code>this</code> by the given vector <code>xyz</code> and store the result in <code>dest</code>.
+     *
+     * @param xyz
+     *          the vector to translate by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBf translate(Vector3fc xyz, AABBf dest);
+
+    /**
+     * Translate <code>this</code> by the vector <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     *
+     * @param x
+     *          the x coordinate to translate by
+     * @param y
+     *          the y coordinate to translate by
+     * @param z
+     *          the z coordinate to translate by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBf translate(float x, float y, float z, AABBf dest);
+
+    /**
+     * Compute the AABB of intersection between <code>this</code> and the given AABB.
+     * <p>
+     * If the two AABBs do not intersect, then the minimum coordinates of <code>this</code>
+     * will have a value of {@link Float#POSITIVE_INFINITY} and the maximum coordinates will have a value of
+     * {@link Float#NEGATIVE_INFINITY}.
+     *
+     * @param other
+     *           the other AABB
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBf intersection(AABBfc other, AABBf dest);
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBdc aabb);
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBfc aabb);
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBic aabb);
+
+    /**
+     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
+     *
+     * @param x
+     *          the x coordinate of the point
+     * @param y
+     *          the y coordinate of the point
+     * @param z
+     *          the z coordinate of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(float x, float y, float z);
+
+    /**
+     * Test whether the given point lies inside this AABB.
+     *
+     * @param point
+     *          the coordinates of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(Vector3fc point);
+
+    /**
+     * Test whether the plane given via its plane equation <code>a*x + b*y + c*z + d = 0</code> intersects this AABB.
+     * <p>
+     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     *
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsPlane(float a, float b, float c, float d);
+
+    /**
+     * Test whether the given plane intersects this AABB.
+     * <p>
+     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     *
+     * @param plane
+     *          the plane
+     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsPlane(Planef plane);
+
+    /**
+     * Test whether <code>this</code> and <code>other</code> intersect.
+     *
+     * @param other
+     *          the other AABB
+     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
+     */
+    boolean intersectsAABB(AABBfc other);
+
+    /**
+     * Test whether this AABB intersects the given sphere with equation
+     * <code>(x - centerX)^2 + (y - centerY)^2 + (z - centerZ)^2 - radiusSquared = 0</code>.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     *
+     * @param centerX
+     *          the x coordinate of the center of the sphere
+     * @param centerY
+     *          the y coordinate of the center of the sphere
+     * @param centerZ
+     *          the z coordinate of the center of the sphere
+     * @param radiusSquared
+     *          the square radius of the sphere
+     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
+     */
+    boolean intersectsSphere(float centerX, float centerY, float centerZ, float radiusSquared);
+
+    /**
+     * Test whether this AABB intersects the given sphere.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     *
+     * @param sphere
+     *          the sphere
+     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
+     */
+    boolean intersectsSphere(Spheref sphere);
+
+    /**
+     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
+     * intersects this AABB.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param originX
+     *          the x coordinate of the ray's origin
+     * @param originY
+     *          the y coordinate of the ray's origin
+     * @param originZ
+     *          the z coordinate of the ray's origin
+     * @param dirX
+     *          the x coordinate of the ray's direction
+     * @param dirY
+     *          the y coordinate of the ray's direction
+     * @param dirZ
+     *          the z coordinate of the ray's direction
+     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
+     */
+    boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ);
+
+    /**
+     * Test whether the given ray intersects this AABB.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param ray
+     *          the ray
+     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
+     */
+    boolean intersectsRay(Rayf ray);
+
+
+
+    /**
+     * Determine whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
+     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param originX
+     *              the x coordinate of the ray's origin
+     * @param originY
+     *              the y coordinate of the ray's origin
+     * @param originZ
+     *              the z coordinate of the ray's origin
+     * @param dirX
+     *              the x coordinate of the ray's direction
+     * @param dirY
+     *              the y coordinate of the ray's direction
+     * @param dirZ
+     *              the z coordinate of the ray's direction
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
+     *              iff the ray intersects this AABB
+     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ, Vector2f result);
+
+
+    /**
+     * Determine whether the given ray intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param ray
+     *              the ray
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
+     *              iff the ray intersects this AABB
+     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsRay(Rayf ray, Vector2f result);
+
+    /**
+     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X, p1Y, p1Z)</code>
+     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param p0X
+     *              the x coordinate of the line segment's first end point
+     * @param p0Y
+     *              the y coordinate of the line segment's first end point
+     * @param p0Z
+     *              the z coordinate of the line segment's first end point
+     * @param p1X
+     *              the x coordinate of the line segment's second end point
+     * @param p1Y
+     *              the y coordinate of the line segment's second end point
+     * @param p1Z
+     *              the z coordinate of the line segment's second end point
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *              iff the line segment intersects this AABB
+     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
+     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
+     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     */
+    int intersectsLineSegment(float p0X, float p0Y, float p0Z, float p1X, float p1Y, float p1Z, Vector2f result);
+
+    /**
+     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param lineSegment
+     *              the line segment
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *              iff the line segment intersects this AABB
+     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
+     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
+     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     */
+    int intersectsLineSegment(LineSegmentf lineSegment, Vector2f result);
+
+    /**
+     * Apply the given {@link Matrix4fc#isAffine() affine} transformation to this
+     * {@link AABBf} and store the resulting AABB into <code>dest</code>.
+     * <p>
+     * The matrix in <code>m</code> <i>must</i> be {@link Matrix4fc#isAffine() affine}.
+     *
+     * @param m
+     *          the affine transformation matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBf transform(Matrix4fc m, AABBf dest);
+
+    /**
+     * Return a string representation of this AABB by formatting the vector components with the given {@link NumberFormat}.
+     *
+     * @param formatter
+     *          the {@link NumberFormat} used to format the vector components with
+     * @return the string representation
+     */
+    String toString(NumberFormat formatter);
+}

--- a/src/org/joml/AABBfc.java
+++ b/src/org/joml/AABBfc.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2020 JOML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.joml;
 
 import java.text.NumberFormat;

--- a/src/org/joml/AABBi.java
+++ b/src/org/joml/AABBi.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
-public class AABBi implements Externalizable {
+public class AABBi implements Externalizable, AABBic {
 
     /**
      * The x coordinate of the minimum corner.
@@ -69,13 +69,13 @@ public class AABBi implements Externalizable {
      * @param source
      *          the {@link AABBi} to copy from
      */
-    public AABBi(AABBi source) {
-        this.minX = source.minX;
-        this.minY = source.minY;
-        this.minZ = source.minZ;
-        this.maxX = source.maxX;
-        this.maxY = source.maxY;
-        this.maxZ = source.maxZ;
+    public AABBi(AABBic source) {
+        this.minX = source.minX();
+        this.minY = source.minY();
+        this.minZ = source.minZ();
+        this.maxX = source.maxX();
+        this.maxY = source.maxY();
+        this.maxZ = source.maxZ();
     }
 
     /**
@@ -120,6 +120,31 @@ public class AABBi implements Externalizable {
         this.maxZ = maxZ;
     }
 
+    public int minX() {
+        return minX;
+    }
+
+    public int minY() {
+        return minY;
+    }
+
+    public int minZ() {
+        return minZ;
+    }
+
+    public int maxX() {
+        return maxX;
+    }
+
+    public int maxY() {
+        return maxY;
+    }
+
+    public int maxZ() {
+        return maxZ;
+    }
+
+
     /**
      * Set the minimum corner coordinates.
      *
@@ -163,13 +188,13 @@ public class AABBi implements Externalizable {
      *            the {@link AABBi} to copy from
      * @return this
      */
-    public AABBi set(AABBi source){
-        this.minX = source.minX;
-        this.minY = source.minY;
-        this.minZ = source.minZ;
-        this.maxX = source.maxX;
-        this.maxY = source.maxY;
-        this.maxZ = source.maxZ;
+    public AABBi set(AABBic source){
+        this.minX = source.minX();
+        this.minY = source.minY();
+        this.minZ = source.minZ();
+        this.maxX = source.maxX();
+        this.maxY = source.maxY();
+        this.maxZ = source.maxZ();
         return this;
     }
 
@@ -186,11 +211,6 @@ public class AABBi implements Externalizable {
         return this;
     }
 
-    /**
-     * Check whether <code>this</code> AABB represents a valid AABB.
-     *
-     * @return <code>true</code> iff this AABB is valid; <code>false</code> otherwise
-     */
     public boolean isValid() {
         return minX < maxX && minY < maxY && minZ < maxZ;
     }
@@ -217,14 +237,6 @@ public class AABBi implements Externalizable {
         return this.setMax(max.x(), max.y(), max.z());
     }
 
-    /**
-     * Get the maximum corner coordinate of the given component.
-     *
-     * @param component
-     *          the component, within <code>[0..2]</code>
-     * @return the maximum coordinate
-     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
-     */
     public int getMax(int component) throws IllegalArgumentException {
         switch (component) {
             case 0:
@@ -238,14 +250,6 @@ public class AABBi implements Externalizable {
         }
     }
 
-    /**
-     * Get the minimum corner coordinate of the given component.
-     *
-     * @param component
-     *          the component, within <code>[0..2]</code>
-     * @return the maximum coordinate
-     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
-     */
     public int getMin(int component) throws IllegalArgumentException {
         switch (component) {
             case 0:
@@ -259,42 +263,18 @@ public class AABBi implements Externalizable {
         }
     }
 
-    /**
-     * Return the center of the aabb
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3f center(Vector3f dest) {
         return dest.set(minX + ((maxX - minX) / 2.0f), minY + ((maxY - minY) / 2.0f), minZ + ((maxZ - minZ) / 2.0f));
     }
 
-    /**
-     * Return the center of the aabb
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3d center(Vector3d dest) {
         return dest.set(minX + ((maxX - minX) / 2.0), minY + ((maxY - minY) / 2.0), minZ + ((maxZ - minZ) / 2.0));
     }
 
-    /**
-     * Extent of the aabb (max - min) / 2.0.
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3d extent(Vector3d dest) {
         return dest.set((maxX - minX) / 2.0, (maxY - minY) / 2.0, (maxZ - minZ) / 2.0);
     }
 
-    /**
-     * Extent of the aabb (max - min) / 2.0.
-     *
-     * @param dest will hold the result
-     * @return dest
-     */
     public Vector3f extent(Vector3f dest) {
         return dest.set((maxX - minX) / 2.0f, (maxY - minY) / 2.0f, (maxZ - minZ) / 2.0f);
     }
@@ -325,20 +305,6 @@ public class AABBi implements Externalizable {
         return union(p.x(), p.y(), p.z(), this);
     }
 
-
-    /**
-     * Compute the union of <code>this</code> and the given point <code>(x, y, z)</code> and store the result in <code>dest</code>.
-     *
-     * @param x
-     *          the x coordinate of the point
-     * @param y
-     *          the y coordinate of the point
-     * @param z
-     *          the z coordinate of the point
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBi union(int x, int y, int z, AABBi dest) {
         dest.minX = this.minX < x ? this.minX : x;
         dest.minY = this.minY < y ? this.minY : y;
@@ -348,15 +314,7 @@ public class AABBi implements Externalizable {
         dest.maxZ = this.maxZ > z ? this.maxZ : z;
         return dest;
     }
-    /**
-     * Compute the union of <code>this</code> and the given point <code>p</code> and store the result in <code>dest</code>.
-     *
-     * @param p
-     *          the point
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
+
     public AABBi union(Vector3ic p, AABBi dest) {
         return union(p.x(), p.y(), p.z(), dest);
     }
@@ -368,26 +326,17 @@ public class AABBi implements Externalizable {
      *          the other {@link AABBi}
      * @return this
      */
-    public AABBi union(AABBi other) {
+    public AABBi union(AABBic other) {
         return this.union(other, this);
     }
 
-    /**
-     * Compute the union of <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
-     *
-     * @param other
-     *          the other {@link AABBi}
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
-    public AABBi union(AABBi other, AABBi dest) {
-        dest.minX = this.minX < other.minX ? this.minX : other.minX;
-        dest.minY = this.minY < other.minY ? this.minY : other.minY;
-        dest.minZ = this.minZ < other.minZ ? this.minZ : other.minZ;
-        dest.maxX = this.maxX > other.maxX ? this.maxX : other.maxX;
-        dest.maxY = this.maxY > other.maxY ? this.maxY : other.maxY;
-        dest.maxZ = this.maxZ > other.maxZ ? this.maxZ : other.maxZ;
+    public AABBi union(AABBic other, AABBi dest) {
+        dest.minX = this.minX < other.minX() ? this.minX : other.minX();
+        dest.minY = this.minY < other.minY() ? this.minY : other.minY();
+        dest.minZ = this.minZ < other.minZ() ? this.minZ : other.minZ();
+        dest.maxX = this.maxX > other.maxX() ? this.maxX : other.maxX();
+        dest.maxY = this.maxY > other.maxY() ? this.maxY : other.maxY();
+        dest.maxZ = this.maxZ > other.maxZ() ? this.maxZ : other.maxZ();
         return dest;
     }
 
@@ -456,19 +405,6 @@ public class AABBi implements Externalizable {
         return translate(x, y, z, this);
     }
 
-    /**
-     * Translate <code>this</code> by the vector <code>(x, y, z)</code> and store the result in <code>dest</code>.
-     *
-     * @param x
-     *          the x coordinate to translate by
-     * @param y
-     *          the y coordinate to translate by
-     * @param z
-     *          the z coordinate to translate by
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBi translate(int x, int y, int z, AABBi dest) {
         dest.minX = minX + x;
         dest.minY = minY + y;
@@ -479,28 +415,14 @@ public class AABBi implements Externalizable {
         return dest;
     }
 
+    public AABBi intersection(AABBic other, AABBi dest) {
+        dest.minX = Math.max(minX, other.minX());
+        dest.minY = Math.max(minY, other.minY());
+        dest.minZ = Math.max(minZ, other.minZ());
 
-    /**
-     * Compute the AABB of intersection between <code>this</code> and the given AABB.
-     * <p>
-     * If the two AABBs do not intersect, then the minimum coordinates of <code>this</code>
-     * will have a value of {@link Integer#MAX_VALUE} and the maximum coordinates will have a value of
-     * {@link Integer#MIN_VALUE}.
-     *
-     * @param other
-     *           the other AABB
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
-    public AABBi intersection(AABBi other, AABBi dest) {
-        dest.minX = Math.max(minX, other.minX);
-        dest.minY = Math.max(minY, other.minY);
-        dest.minZ = Math.max(minZ, other.minZ);
-
-        dest.maxX = Math.min(maxX, other.maxX);
-        dest.maxY = Math.min(maxY, other.maxY);
-        dest.maxZ = Math.min(maxZ, other.maxZ);
+        dest.maxX = Math.min(maxX, other.maxX());
+        dest.maxY = Math.min(maxY, other.maxY());
+        dest.maxZ = Math.min(maxZ, other.maxZ());
         return dest.validate();
     }
 
@@ -516,338 +438,90 @@ public class AABBi implements Externalizable {
      *           the other AABB
      * @return this
      */
-    public AABBi intersection(AABBi other) {
+    public AABBi intersection(AABBic other) {
         return intersection(other, this);
     }
 
-
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBd aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBdc aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBf aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBfc aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-    /**
-     * Check if this AABB contains the given <code>AABB</code>.
-     *
-     * @param aabb
-     *          the AABB to test
-     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
-     */
-    public boolean containsAABB(AABBi aabb) {
-        return aabb.minX >= minX && aabb.maxX <= maxX &&
-            aabb.minY >= minY && aabb.maxY <= maxY &&
-            aabb.minZ >= minZ && aabb.maxZ <= maxZ;
+    public boolean containsAABB(AABBic aabb) {
+        return aabb.minX() >= minX && aabb.maxX() <= maxX &&
+            aabb.minY() >= minY && aabb.maxY() <= maxY &&
+            aabb.minZ() >= minZ && aabb.maxZ() <= maxZ;
     }
 
-    /**
-     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
-     *
-     * @param x
-     *          the x coordinate of the point
-     * @param y
-     *          the y coordinate of the point
-     * @param z
-     *          the z coordinate of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(int x, int y, int z){
         return x >= minX && y >= minY && z >= minZ && x <= maxX && y <= maxY && z <= maxZ;
     }
 
-    /**
-     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
-     *
-     * @param x
-     *          the x coordinate of the point
-     * @param y
-     *          the y coordinate of the point
-     * @param z
-     *          the z coordinate of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(float x, float y, float z){
         return x >= minX && y >= minY && z >= minZ && x <= maxX && y <= maxY && z <= maxZ;
     }
 
-
-    /**
-     * Test whether the given point lies inside this AABB.
-     *
-     * @param point
-     *          the coordinates of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(Vector3ic point) {
         return containsPoint(point.x(), point.y(), point.z());
     }
 
-    /**
-     * Test whether the given point lies inside this AABB.
-     *
-     * @param point
-     *          the coordinates of the point
-     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
-     */
     public boolean containsPoint(Vector3fc point) {
         return containsPoint(point.x(), point.y(), point.z());
     }
 
-    /**
-     * Test whether the plane given via its plane equation <code>a*x + b*y + c*z + d = 0</code> intersects this AABB.
-     * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
-     *
-     * @param a
-     *          the x factor in the plane equation
-     * @param b
-     *          the y factor in the plane equation
-     * @param c
-     *          the z factor in the plane equation
-     * @param d
-     *          the constant in the plane equation
-     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsPlane(float a, float b, float c, float d) {
         return Intersectionf.testAabPlane(minX, minY, minZ, maxX, maxY, maxZ, a, b, c, d);
     }
 
-    /**
-     * Test whether the given plane intersects this AABB.
-     * <p>
-     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
-     *
-     * @param plane
-     *          the plane
-     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsPlane(Planef plane) {
         return Intersectionf.testAabPlane(this, plane);
     }
 
-    /**
-     * Test whether <code>this</code> and <code>other</code> intersect.
-     *
-     * @param other
-     *          the other AABB
-     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
-     */
-    public boolean intersectsAABB(AABBi other) {
-        return this.maxX >= other.minX && this.maxY >= other.minY && this.maxZ >= other.minZ &&
-            this.minX <= other.maxX && this.minY <= other.maxY && this.minZ <= other.maxZ;
+    public boolean intersectsAABB(AABBic other) {
+        return this.maxX >= other.minX() && this.maxY >= other.minY() && this.maxZ >= other.minZ() &&
+            this.minX <= other.maxX() && this.minY <= other.maxY() && this.minZ <= other.maxZ();
     }
 
-    /**
-     * Test whether <code>this</code> and <code>other</code> intersect.
-     *
-     * @param other
-     *          the other AABB
-     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
-     */
-    public boolean intersectsAABB(AABBf other) {
-        return this.maxX >= other.minX && this.maxY >= other.minY && this.maxZ >= other.minZ &&
-            this.minX <= other.maxX && this.minY <= other.maxY && this.minZ <= other.maxZ;
+    public boolean intersectsAABB(AABBfc other) {
+        return this.maxX >= other.minX() && this.maxY >= other.minY() && this.maxZ >= other.minZ() &&
+            this.minX <= other.maxX() && this.minY <= other.maxY() && this.minZ <= other.maxZ();
     }
 
-    /**
-     * Test whether this AABB intersects the given sphere with equation
-     * <code>(x - centerX)^2 + (y - centerY)^2 + (z - centerZ)^2 - radiusSquared = 0</code>.
-     * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
-     *
-     * @param centerX
-     *          the x coordinate of the center of the sphere
-     * @param centerY
-     *          the y coordinate of the center of the sphere
-     * @param centerZ
-     *          the z coordinate of the center of the sphere
-     * @param radiusSquared
-     *          the square radius of the sphere
-     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
-     */
     public boolean intersectsSphere(float centerX, float centerY, float centerZ, float radiusSquared) {
         return Intersectionf.testAabSphere(minX, minY, minZ, maxX, maxY, maxZ, centerX, centerY, centerZ, radiusSquared);
     }
 
-    /**
-     * Test whether this AABB intersects the given sphere.
-     * <p>
-     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
-     *
-     * @param sphere
-     *          the sphere
-     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
-     */
     public boolean intersectsSphere(Spheref sphere) {
         return Intersectionf.testAabSphere(this, sphere);
     }
 
-
-    /**
-     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
-     * intersects this AABB.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     *
-     * @param originX
-     *          the x coordinate of the ray's origin
-     * @param originY
-     *          the y coordinate of the ray's origin
-     * @param originZ
-     *          the z coordinate of the ray's origin
-     * @param dirX
-     *          the x coordinate of the ray's direction
-     * @param dirY
-     *          the y coordinate of the ray's direction
-     * @param dirZ
-     *          the z coordinate of the ray's direction
-     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
-     */
     public boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ) {
         return Intersectionf.testRayAab(originX, originY, originZ, dirX, dirY, dirZ, minX, minY, minZ, maxX, maxY, maxZ);
     }
 
-    /**
-     * Test whether the given ray intersects this AABB.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     *
-     * @param ray
-     *          the ray
-     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
-     */
     public boolean intersectsRay(Rayf ray) {
         return Intersectionf.testRayAab(ray, this);
     }
 
-    /**
-     * Determine whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
-     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     *
-     * @param originX
-     *              the x coordinate of the ray's origin
-     * @param originY
-     *              the y coordinate of the ray's origin
-     * @param originZ
-     *              the z coordinate of the ray's origin
-     * @param dirX
-     *              the x coordinate of the ray's direction
-     * @param dirY
-     *              the y coordinate of the ray's direction
-     * @param dirZ
-     *              the z coordinate of the ray's direction
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
-     *              iff the ray intersects this AABB
-     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ, Vector2f result) {
         return Intersectionf.intersectRayAab(originX, originY, originZ, dirX, dirY, dirZ, minX, minY, minZ, maxX, maxY, maxZ, result);
     }
 
-    /**
-     * Determine whether the given ray intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     *
-     * @param ray
-     *              the ray
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
-     *              iff the ray intersects this AABB
-     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
-     */
     public boolean intersectsRay(Rayf ray, Vector2f result) {
         return Intersectionf.intersectRayAab(ray, this, result);
     }
 
-    /**
-     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X, p1Y, p1Z)</code>
-     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     *
-     * @param p0X
-     *              the x coordinate of the line segment's first end point
-     * @param p0Y
-     *              the y coordinate of the line segment's first end point
-     * @param p0Z
-     *              the z coordinate of the line segment's first end point
-     * @param p1X
-     *              the x coordinate of the line segment's second end point
-     * @param p1Y
-     *              the y coordinate of the line segment's second end point
-     * @param p1Z
-     *              the z coordinate of the line segment's second end point
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
-     */
     public int intersectLineSegment(float p0X, float p0Y, float p0Z, float p1X, float p1Y, float p1Z, Vector2f result) {
         return Intersectionf.intersectLineSegmentAab(p0X, p0Y, p0Z, p1X, p1Y, p1Z, minX, minY, minZ, maxX, maxY, maxZ, result);
     }
 
-    /**
-     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
-     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
-     * <p>
-     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
-     * <p>
-     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
-     *
-     * @param lineSegment
-     *              the line segment
-     * @param result
-     *              a vector which will hold the resulting values of the parameter
-     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
-     *              iff the line segment intersects this AABB
-     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
-     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
-     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
-     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
-     */
     public int intersectLineSegment(LineSegmentf lineSegment, Vector2f result) {
         return Intersectionf.intersectLineSegmentAab(lineSegment, this, result);
     }
@@ -866,18 +540,6 @@ public class AABBi implements Externalizable {
         return transform(m, this);
     }
 
-    /**
-     * Apply the given {@link Matrix4fc#isAffine() affine} transformation to this
-     * {@link AABBi} and store the resulting AABB into <code>dest</code>.
-     * <p>
-     * The matrix in <code>m</code> <i>must</i> be {@link Matrix4fc#isAffine() affine}.
-     *
-     * @param m
-     *          the affine transformation matrix
-     * @param dest
-     *          will hold the result
-     * @return dest
-     */
     public AABBi transform(Matrix4fc m, AABBi dest) {
         float dx = maxX - minX, dy = maxY - minY, dz = maxZ - minZ;
         float minx = Float.POSITIVE_INFINITY, miny = Float.POSITIVE_INFINITY, minz = Float.POSITIVE_INFINITY;

--- a/src/org/joml/AABBic.java
+++ b/src/org/joml/AABBic.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017-2020 JOML
+ * Copyright (c) 2020 JOML
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,9 @@
  */
 package org.joml;
 
+/**
+ * Interface to a read-only view of a AABB of ints
+ */
 public interface AABBic {
 
     /**

--- a/src/org/joml/AABBic.java
+++ b/src/org/joml/AABBic.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017-2020 JOML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.joml;
 
 public interface AABBic {

--- a/src/org/joml/AABBic.java
+++ b/src/org/joml/AABBic.java
@@ -1,0 +1,474 @@
+package org.joml;
+
+public interface AABBic {
+
+    /**
+     * @return The x coordinate of the minimum corner.
+     */
+    int minX();
+
+    /**
+     * @return The y coordinate of the minimum corner.
+     */
+    int minY();
+
+    /**
+     * @return The z coordinate of the minimum corner.
+     */
+    int minZ();
+
+    /**
+     * @return The x coordinate of the maximum corner.
+     */
+    int maxX();
+
+    /**
+     * @return The y coordinate of the maximum corner.
+     */
+    int maxY();
+
+    /**
+     * @return The z coordinate of the maximum corner.
+     */
+    int maxZ();
+
+    /**
+     * Check whether <code>this</code> AABB represents a valid AABB.
+     *
+     * @return <code>true</code> iff this AABB is valid; <code>false</code> otherwise
+     */
+    boolean isValid();
+
+    /**
+     * Get the maximum corner coordinate of the given component.
+     *
+     * @param component
+     *          the component, within <code>[0..2]</code>
+     * @return the maximum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
+     */
+    int getMax(int component);
+
+
+    /**
+     * Get the minimum corner coordinate of the given component.
+     *
+     * @param component
+     *          the component, within <code>[0..2]</code>
+     * @return the maximum coordinate
+     * @throws IllegalArgumentException if <code>component</code> is not within <code>[0..2]</code>
+     */
+    int getMin(int component);
+
+
+    /**
+     * Return the center of the aabb
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3f center(Vector3f dest);
+
+
+    /**
+     * Return the center of the aabb
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3d center(Vector3d dest);
+
+
+    /**
+     * Extent of the aabb (max - min) / 2.0.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3d extent(Vector3d dest);
+
+
+    /**
+     * Extent of the aabb (max - min) / 2.0.
+     *
+     * @param dest will hold the result
+     * @return dest
+     */
+    Vector3f extent(Vector3f dest);
+
+
+    /**
+     * Compute the union of <code>this</code> and the given point <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     *
+     * @param x
+     *          the x coordinate of the point
+     * @param y
+     *          the y coordinate of the point
+     * @param z
+     *          the z coordinate of the point
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBi union(int x, int y, int z, AABBi dest);
+
+    /**
+     * Compute the union of <code>this</code> and the given point <code>p</code> and store the result in <code>dest</code>.
+     *
+     * @param p
+     *          the point
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBi union(Vector3ic p, AABBi dest);
+
+
+
+    /**
+     * Compute the union of <code>this</code> and <code>other</code> and store the result in <code>dest</code>.
+     *
+     * @param other
+     *          the other {@link AABBi}
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBi union(AABBic other, AABBi dest);
+
+    /**
+     * Translate <code>this</code> by the vector <code>(x, y, z)</code> and store the result in <code>dest</code>.
+     *
+     * @param x
+     *          the x coordinate to translate by
+     * @param y
+     *          the y coordinate to translate by
+     * @param z
+     *          the z coordinate to translate by
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBi translate(int x, int y, int z, AABBi dest);
+
+
+    /**
+     * Compute the AABB of intersection between <code>this</code> and the given AABB.
+     * <p>
+     * If the two AABBs do not intersect, then the minimum coordinates of <code>this</code>
+     * will have a value of {@link Integer#MAX_VALUE} and the maximum coordinates will have a value of
+     * {@link Integer#MIN_VALUE}.
+     *
+     * @param other
+     *           the other AABB
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBi intersection(AABBic other, AABBi dest);
+
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBdc aabb);
+
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBfc aabb);
+
+    /**
+     * Check if this AABB contains the given <code>AABB</code>.
+     *
+     * @param aabb
+     *          the AABB to test
+     * @return <code>true</code> iff this AABB contains the AABB; <code>false</code> otherwise
+     */
+    boolean containsAABB(AABBic aabb);
+
+
+    /**
+     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
+     *
+     * @param x
+     *          the x coordinate of the point
+     * @param y
+     *          the y coordinate of the point
+     * @param z
+     *          the z coordinate of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(int x, int y, int z);
+
+
+    /**
+     * Test whether the point <code>(x, y, z)</code> lies inside this AABB.
+     *
+     * @param x
+     *          the x coordinate of the point
+     * @param y
+     *          the y coordinate of the point
+     * @param z
+     *          the z coordinate of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(float x, float y, float z);
+
+
+    /**
+     * Test whether the given point lies inside this AABB.
+     *
+     * @param point
+     *          the coordinates of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(Vector3ic point);
+
+
+    /**
+     * Test whether the given point lies inside this AABB.
+     *
+     * @param point
+     *          the coordinates of the point
+     * @return <code>true</code> iff the given point lies inside this AABB; <code>false</code> otherwise
+     */
+    boolean containsPoint(Vector3fc point);
+
+    /**
+     * Test whether the plane given via its plane equation <code>a*x + b*y + c*z + d = 0</code> intersects this AABB.
+     * <p>
+     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     *
+     * @param a
+     *          the x factor in the plane equation
+     * @param b
+     *          the y factor in the plane equation
+     * @param c
+     *          the z factor in the plane equation
+     * @param d
+     *          the constant in the plane equation
+     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsPlane(float a, float b, float c, float d);
+
+
+    /**
+     * Test whether the given plane intersects this AABB.
+     * <p>
+     * Reference: <a href="http://www.lighthouse3d.com/tutorials/view-frustum-culling/geometric-approach-testing-boxes-ii/">http://www.lighthouse3d.com</a> ("Geometric Approach - Testing Boxes II")
+     *
+     * @param plane
+     *          the plane
+     * @return <code>true</code> iff the plane intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsPlane(Planef plane);
+
+    /**
+     * Test whether <code>this</code> and <code>other</code> intersect.
+     *
+     * @param other
+     *          the other AABB
+     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
+     */
+    boolean intersectsAABB(AABBic other);
+
+    /**
+     * Test whether <code>this</code> and <code>other</code> intersect.
+     *
+     * @param other
+     *          the other AABB
+     * @return <code>true</code> iff both AABBs intersect; <code>false</code> otherwise
+     */
+    boolean intersectsAABB(AABBfc other);
+
+    /**
+     * Test whether this AABB intersects the given sphere with equation
+     * <code>(x - centerX)^2 + (y - centerY)^2 + (z - centerZ)^2 - radiusSquared = 0</code>.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     *
+     * @param centerX
+     *          the x coordinate of the center of the sphere
+     * @param centerY
+     *          the y coordinate of the center of the sphere
+     * @param centerZ
+     *          the z coordinate of the center of the sphere
+     * @param radiusSquared
+     *          the square radius of the sphere
+     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
+     */
+    boolean intersectsSphere(float centerX, float centerY, float centerZ, float radiusSquared) ;
+
+    /**
+     * Test whether this AABB intersects the given sphere.
+     * <p>
+     * Reference: <a href="http://stackoverflow.com/questions/4578967/cube-sphere-intersection-test#answer-4579069">http://stackoverflow.com</a>
+     *
+     * @param sphere
+     *          the sphere
+     * @return <code>true</code> iff this AABB and the sphere intersect; <code>false</code> otherwise
+     */
+    boolean intersectsSphere(Spheref sphere);
+
+    /**
+     * Test whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
+     * intersects this AABB.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param originX
+     *          the x coordinate of the ray's origin
+     * @param originY
+     *          the y coordinate of the ray's origin
+     * @param originZ
+     *          the z coordinate of the ray's origin
+     * @param dirX
+     *          the x coordinate of the ray's direction
+     * @param dirY
+     *          the y coordinate of the ray's direction
+     * @param dirZ
+     *          the z coordinate of the ray's direction
+     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
+     */
+    boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ);
+
+
+    /**
+     * Test whether the given ray intersects this AABB.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param ray
+     *          the ray
+     * @return <code>true</code> if this AABB and the ray intersect; <code>false</code> otherwise
+     */
+    boolean intersectsRay(Rayf ray);
+    /**
+     * Determine whether the given ray with the origin <code>(originX, originY, originZ)</code> and direction <code>(dirX, dirY, dirZ)</code>
+     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param originX
+     *              the x coordinate of the ray's origin
+     * @param originY
+     *              the y coordinate of the ray's origin
+     * @param originZ
+     *              the z coordinate of the ray's origin
+     * @param dirX
+     *              the x coordinate of the ray's direction
+     * @param dirY
+     *              the y coordinate of the ray's direction
+     * @param dirZ
+     *              the z coordinate of the ray's direction
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
+     *              iff the ray intersects this AABB
+     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsRay(float originX, float originY, float originZ, float dirX, float dirY, float dirZ, Vector2f result);
+
+    /**
+     * Determine whether the given ray intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + t * dir</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a ray whose origin lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param ray
+     *              the ray
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = origin + t * dir</i> of the near and far point of intersection
+     *              iff the ray intersects this AABB
+     * @return <code>true</code> if the given ray intersects this AABB; <code>false</code> otherwise
+     */
+    boolean intersectsRay(Rayf ray, Vector2f result);
+
+    /**
+     * Determine whether the undirected line segment with the end points <code>(p0X, p0Y, p0Z)</code> and <code>(p1X, p1Y, p1Z)</code>
+     * intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param p0X
+     *              the x coordinate of the line segment's first end point
+     * @param p0Y
+     *              the y coordinate of the line segment's first end point
+     * @param p0Z
+     *              the z coordinate of the line segment's first end point
+     * @param p1X
+     *              the x coordinate of the line segment's second end point
+     * @param p1Y
+     *              the y coordinate of the line segment's second end point
+     * @param p1Z
+     *              the z coordinate of the line segment's second end point
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *              iff the line segment intersects this AABB
+     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
+     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
+     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     */
+    int intersectLineSegment(float p0X, float p0Y, float p0Z, float p1X, float p1Y, float p1Z, Vector2f result) ;
+
+    /**
+     * Determine whether the given undirected line segment intersects this AABB, and return the values of the parameter <i>t</i> in the ray equation
+     * <i>p(t) = origin + p0 * (p1 - p0)</i> of the near and far point of intersection.
+     * <p>
+     * This method returns <code>true</code> for a line segment whose either end point lies inside this AABB.
+     * <p>
+     * Reference: <a href="https://dl.acm.org/citation.cfm?id=1198748">An Efficient and Robust Ray–Box Intersection</a>
+     *
+     * @param lineSegment
+     *              the line segment
+     * @param result
+     *              a vector which will hold the resulting values of the parameter
+     *              <i>t</i> in the ray equation <i>p(t) = p0 + t * (p1 - p0)</i> of the near and far point of intersection
+     *              iff the line segment intersects this AABB
+     * @return {@link Intersectionf#INSIDE} if the line segment lies completely inside of this AABB; or
+     *         {@link Intersectionf#OUTSIDE} if the line segment lies completely outside of this AABB; or
+     *         {@link Intersectionf#ONE_INTERSECTION} if one of the end points of the line segment lies inside of this AABB; or
+     *         {@link Intersectionf#TWO_INTERSECTION} if the line segment intersects two sides of this AABB or lies on an edge or a side of this AABB
+     */
+    int intersectLineSegment(LineSegmentf lineSegment, Vector2f result);
+
+    /**
+     * Apply the given {@link Matrix4fc#isAffine() affine} transformation to this
+     * {@link AABBi} and store the resulting AABB into <code>dest</code>.
+     * <p>
+     * The matrix in <code>m</code> <i>must</i> be {@link Matrix4fc#isAffine() affine}.
+     *
+     * @param m
+     *          the affine transformation matrix
+     * @param dest
+     *          will hold the result
+     * @return dest
+     */
+    AABBi transform(Matrix4fc m, AABBi dest);
+
+}


### PR DESCRIPTION
Here is a read-only interface for AABB. I have some methods with an AABB I would like to expose but would prefer if it was not possible to modify. Here is an implementation that is similar to Vectror*c type interfaces. I would like to also do this for Circle/Ray/Sphere. 