### PR TITLE
Add Vector3i(float/double x,y,z) and test case

### DIFF
--- a/src/org/joml/Vector3i.java
+++ b/src/org/joml/Vector3i.java
@@ -122,6 +122,44 @@ public class Vector3i implements Externalizable, Vector3ic {
     }
 
     /**
+     * Create a new {@link Vector3i} with the given component values and
+     * round using the given {@link RoundingMode}.
+     *
+     * @param x
+     *          the value of x
+     * @param y
+     *          the value of y
+     * @param z
+     *          the value of z
+     * @param mode
+     *          the {@link RoundingMode} to use
+     */
+    public Vector3i(float x, float y, float z, int mode) {
+        this.x = Math.roundUsing(x, mode);
+        this.y = Math.roundUsing(y, mode);
+        this.z = Math.roundUsing(z, mode);
+    }
+
+    /**
+     * Create a new {@link Vector3i} with the given component values and
+     * round using the given {@link RoundingMode}.
+     *
+     * @param x
+     *          the value of x
+     * @param y
+     *          the value of y
+     * @param z
+     *          the value of z
+     * @param mode
+     *          the {@link RoundingMode} to use
+     */
+    public Vector3i(double x, double y, double z, int mode) {
+        this.x = Math.roundUsing(x, mode);
+        this.y = Math.roundUsing(y, mode);
+        this.z = Math.roundUsing(z, mode);
+    }
+    
+    /**
      * Create a new {@link Vector3i} with the first two components from the
      * given <code>v</code> and the given <code>z</code> and round using the given {@link RoundingMode}.
      *
@@ -133,9 +171,9 @@ public class Vector3i implements Externalizable, Vector3ic {
      *          the {@link RoundingMode} to use
      */
     public Vector3i(Vector2fc v, float z, int mode) {
-        x = Math.roundUsing(v.x(), mode);
-        y = Math.roundUsing(v.y(), mode);
-        z = Math.roundUsing(z, mode);
+        this.x = Math.roundUsing(v.x(), mode);
+        this.y = Math.roundUsing(v.y(), mode);
+        this.z = Math.roundUsing(z, mode);
     }
 
     /**
@@ -148,9 +186,9 @@ public class Vector3i implements Externalizable, Vector3ic {
      *          the {@link RoundingMode} to use
      */
     public Vector3i(Vector3fc v, int mode) {
-        x = Math.roundUsing(v.x(), mode);
-        y = Math.roundUsing(v.y(), mode);
-        z = Math.roundUsing(v.z(), mode);
+        this.x = Math.roundUsing(v.x(), mode);
+        this.y = Math.roundUsing(v.y(), mode);
+        this.z = Math.roundUsing(v.z(), mode);
     }
 
     /**
@@ -165,9 +203,9 @@ public class Vector3i implements Externalizable, Vector3ic {
      *          the {@link RoundingMode} to use
      */
     public Vector3i(Vector2dc v, float z, int mode) {
-        x = Math.roundUsing(v.x(), mode);
-        y = Math.roundUsing(v.y(), mode);
-        z = Math.roundUsing(z, mode);
+        this.x = Math.roundUsing(v.x(), mode);
+        this.y = Math.roundUsing(v.y(), mode);
+        this.z = Math.roundUsing(z, mode);
     }
 
     /**
@@ -180,9 +218,9 @@ public class Vector3i implements Externalizable, Vector3ic {
      *          the {@link RoundingMode} to use
      */
     public Vector3i(Vector3dc v, int mode) {
-        x = Math.roundUsing(v.x(), mode);
-        y = Math.roundUsing(v.y(), mode);
-        z = Math.roundUsing(v.z(), mode);
+        this.x = Math.roundUsing(v.x(), mode);
+        this.y = Math.roundUsing(v.y(), mode);
+        this.z = Math.roundUsing(v.z(), mode);
     }
 
     /**

--- a/test/org/joml/test/Vector3iTest.java
+++ b/test/org/joml/test/Vector3iTest.java
@@ -38,7 +38,7 @@ public class Vector3iTest extends TestCase {
     public static void testVector3iRounding() {
         Vector3i v1 = new Vector3i(0.0f,.6f,.7f, RoundingMode.FLOOR);
         Vector3i v2 = new Vector3i(9.5f,1.6f,5.0f, RoundingMode.FLOOR);
-        Vector3i v3 = new Vector3i(new Vector3f(9.5f,1.6f,5.0f), RoundingMode.FLOOR);
+        Vector3i v3 = new Vector3i(new Vector3f(0.0f,.6f,.7f), RoundingMode.FLOOR);
         Vector3i v4 = new Vector3i(new Vector3d(9.5f,1.6f,5.0f), RoundingMode.FLOOR);
 
         assertEquals(v1, new Vector3i(0,0,0));

--- a/test/org/joml/test/Vector3iTest.java
+++ b/test/org/joml/test/Vector3iTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015-2020 JOML.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.joml.test;
 
 import junit.framework.TestCase;

--- a/test/org/joml/test/Vector3iTest.java
+++ b/test/org/joml/test/Vector3iTest.java
@@ -1,0 +1,38 @@
+package org.joml.test;
+
+import junit.framework.TestCase;
+import org.joml.RoundingMode;
+import org.joml.Vector2d;
+import org.joml.Vector2f;
+import org.joml.Vector3d;
+import org.joml.Vector3f;
+import org.joml.Vector3i;
+
+/**
+ * Test class for {@link Vector3i}.
+ */
+public class Vector3iTest extends TestCase {
+    public static void testVector3iRounding() {
+        Vector3i v1 = new Vector3i(0.0f,.6f,.7f, RoundingMode.FLOOR);
+        Vector3i v2 = new Vector3i(9.5f,1.6f,5.0f, RoundingMode.FLOOR);
+        Vector3i v3 = new Vector3i(new Vector3f(9.5f,1.6f,5.0f), RoundingMode.FLOOR);
+        Vector3i v4 = new Vector3i(new Vector3d(9.5f,1.6f,5.0f), RoundingMode.FLOOR);
+
+        assertEquals(v1, new Vector3i(0,0,0));
+        assertEquals(v2, new Vector3i(9,1,5));
+        assertEquals(v3, new Vector3i(0,0,0));
+        assertEquals(v4, new Vector3i(9,1,5));
+    }
+
+    public static void testVector3iRoundingVector2() {
+        Vector3i v1 = new Vector3i(new Vector2f(0.0f,.6f),.7f, RoundingMode.FLOOR);
+        Vector3i v2 = new Vector3i(new Vector2f(9.5f,1.6f),5.0f, RoundingMode.FLOOR);
+        Vector3i v3 = new Vector3i(new Vector2d(0.0f,.6f),.7f, RoundingMode.FLOOR);
+        Vector3i v4 = new Vector3i(new Vector2d(9.5f,1.6f),5.0f, RoundingMode.FLOOR);
+
+        assertEquals(v1, new Vector3i(0,0,0));
+        assertEquals(v2, new Vector3i(9,1,5));
+        assertEquals(v3, new Vector3i(0,0,0));
+        assertEquals(v4, new Vector3i(9,1,5));
+    }
+}

--- a/test/org/joml/test/Vector3iTest.java
+++ b/test/org/joml/test/Vector3iTest.java
@@ -38,24 +38,49 @@ public class Vector3iTest extends TestCase {
     public static void testVector3iRounding() {
         Vector3i v1 = new Vector3i(0.0f,.6f,.7f, RoundingMode.FLOOR);
         Vector3i v2 = new Vector3i(9.5f,1.6f,5.0f, RoundingMode.FLOOR);
+
         Vector3i v3 = new Vector3i(new Vector3f(0.0f,.6f,.7f), RoundingMode.FLOOR);
         Vector3i v4 = new Vector3i(new Vector3d(9.5f,1.6f,5.0f), RoundingMode.FLOOR);
 
+        Vector3i v5 = new Vector3i(0.0f,.6f,.7f, RoundingMode.CEILING);
+        Vector3i v6 = new Vector3i(9.5f,1.6f,5.0f, RoundingMode.CEILING);
+
+        Vector3i v7 = new Vector3i(new Vector3f(0.0f,.6f,.7f), RoundingMode.CEILING);
+        Vector3i v8 = new Vector3i(new Vector3d(9.5f,1.6f,5.0f), RoundingMode.CEILING);
+
+
         assertEquals(v1, new Vector3i(0,0,0));
         assertEquals(v2, new Vector3i(9,1,5));
+
         assertEquals(v3, new Vector3i(0,0,0));
         assertEquals(v4, new Vector3i(9,1,5));
+
+        assertEquals(v5, new Vector3i(0,1,1));
+        assertEquals(v6, new Vector3i(10,2,5));
+
+        assertEquals(v7, new Vector3i(0,1,1));
+        assertEquals(v8, new Vector3i(10,2,5));
+
     }
 
     public static void testVector3iRoundingVector2() {
         Vector3i v1 = new Vector3i(new Vector2f(0.0f,.6f),.7f, RoundingMode.FLOOR);
         Vector3i v2 = new Vector3i(new Vector2f(9.5f,1.6f),5.0f, RoundingMode.FLOOR);
+
         Vector3i v3 = new Vector3i(new Vector2d(0.0f,.6f),.7f, RoundingMode.FLOOR);
         Vector3i v4 = new Vector3i(new Vector2d(9.5f,1.6f),5.0f, RoundingMode.FLOOR);
 
+        Vector3i v5 = new Vector3i(new Vector2f(0.0f,.6f),.7f, RoundingMode.CEILING);
+        Vector3i v6 = new Vector3i(new Vector2d(9.5f,1.6f),5.0f, RoundingMode.CEILING);
+
+
         assertEquals(v1, new Vector3i(0,0,0));
         assertEquals(v2, new Vector3i(9,1,5));
+
         assertEquals(v3, new Vector3i(0,0,0));
         assertEquals(v4, new Vector3i(9,1,5));
+
+        assertEquals(v5, new Vector3i(0,1,1));
+        assertEquals(v6, new Vector3i(10,2,5));
     }
 }


### PR DESCRIPTION
I noticed that Vector3i(Vector2dc,float/double z) only modifies the local value and does not apply those value to Vector3i. I also added new Vector3i(float/double, mode). 

```
Vector3i v1 = new Vector3i(0.0f,.6f,.7f, RoundingMode.FLOOR);
Vector3i v3 = new Vector3i(new Vector3f(9.5f,1.6f,5.0f), RoundingMode.FLOOR);
Vector3i v4 = new Vector3i(new Vector2d(9.5f,1.6f),5.0f, RoundingMode.FLOOR);
```

