### PR TITLE
Fix sign error in GeometryUtils.perpendicular()

### DIFF
--- a/src/org/joml/GeometryUtils.java
+++ b/src/org/joml/GeometryUtils.java
@@ -60,7 +60,7 @@ public class GeometryUtils {
             dest1.z = -y;
             mag = magX;
         } else if (magY > magZ) {
-            dest1.x = z;
+            dest1.x = -z;
             dest1.y = 0;
             dest1.z = x;
             mag = magY;


### PR DESCRIPTION
There is a typo in one of the cases:
(z,0,x) is not perpendicular to (x,y,z), but
(-z,0,x) is.