### PR TITLE
Change `Matrix4f.set3x3(Matrix4f)` to `Matrix4f.set3x3(Matrix4fc)`

### DIFF
--- a/src/main/java/org/joml/Matrix2d.java
+++ b/src/main/java/org/joml/Matrix2d.java
@@ -66,10 +66,8 @@ public class Matrix2d implements Externalizable, Cloneable, Matrix2dc {
      *          the {@link Matrix2dc} to copy the values from
      */
     public Matrix2d(Matrix2dc mat) {
-        if (mat instanceof Matrix2d) {
-            MemUtil.INSTANCE.copy((Matrix2d) mat, this);
-        } else {
-            setMatrix2dc(mat);
+        if (mat != this) {
+            MemUtil.INSTANCE.copy(mat, this);
         }
     }
 
@@ -93,11 +91,7 @@ public class Matrix2d implements Externalizable, Cloneable, Matrix2dc {
      *          the {@link Matrix3dc} to copy the values from
      */
     public Matrix2d(Matrix3dc mat) {
-        if (mat instanceof Matrix3d) {
-            MemUtil.INSTANCE.copy((Matrix3d) mat, this);
-        } else {
-            setMatrix3dc(mat);
-        }
+        MemUtil.INSTANCE.copy(mat, this);
     }
 
     /**
@@ -277,20 +271,11 @@ public class Matrix2d implements Externalizable, Cloneable, Matrix2dc {
      * @return this
      */
     public Matrix2d set(Matrix2dc m) {
-        if (m == this)
-            return this;
-        else if (m instanceof Matrix2d) {
-            MemUtil.INSTANCE.copy((Matrix2d) m, this);
-        } else {
-            setMatrix2dc(m);
+        if (m != this)
+        {
+            MemUtil.INSTANCE.copy(m, this);
         }
         return this;
-    }
-    private void setMatrix2dc(Matrix2dc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
     }
 
     /**
@@ -316,18 +301,8 @@ public class Matrix2d implements Externalizable, Cloneable, Matrix2dc {
      * @return this
      */
     public Matrix2d set(Matrix3x2dc m) {
-        if (m instanceof Matrix3x2d) {
-            MemUtil.INSTANCE.copy((Matrix3x2d) m, this);
-        } else {
-            setMatrix3x2dc(m);
-        }
+        MemUtil.INSTANCE.copy(m, this);
         return this;
-    }
-    private void setMatrix3x2dc(Matrix3x2dc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
     }
 
     /**
@@ -353,18 +328,8 @@ public class Matrix2d implements Externalizable, Cloneable, Matrix2dc {
      * @return this
      */
     public Matrix2d set(Matrix3dc m) {
-        if (m instanceof Matrix3d) {
-            MemUtil.INSTANCE.copy((Matrix3d) m, this);
-        } else {
-            setMatrix3dc(m);
-        }
+        MemUtil.INSTANCE.copy(m, this);
         return this;
-    }
-    private void setMatrix3dc(Matrix3dc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
     }
 
     /**

--- a/src/main/java/org/joml/Matrix2f.java
+++ b/src/main/java/org/joml/Matrix2f.java
@@ -65,10 +65,8 @@ public class Matrix2f implements Externalizable, Cloneable, Matrix2fc {
      *          the {@link Matrix2fc} to copy the values from
      */
     public Matrix2f(Matrix2fc mat) {
-        if (mat instanceof Matrix2f) {
-            MemUtil.INSTANCE.copy((Matrix2f) mat, this);
-        } else {
-            setMatrix2fc(mat);
+        if (mat != this) {
+            MemUtil.INSTANCE.copy(mat, this);
         }
     }
 
@@ -79,11 +77,7 @@ public class Matrix2f implements Externalizable, Cloneable, Matrix2fc {
      *          the {@link Matrix3fc} to copy the values from
      */
     public Matrix2f(Matrix3fc mat) {
-        if (mat instanceof Matrix3f) {
-            MemUtil.INSTANCE.copy((Matrix3f) mat, this);
-        } else {
-            setMatrix3fc(mat);
-        }
+        MemUtil.INSTANCE.copy(mat, this);
     }
 
     /**
@@ -250,12 +244,8 @@ public class Matrix2f implements Externalizable, Cloneable, Matrix2fc {
      * @return this
      */
     public Matrix2f set(Matrix2fc m) {
-        if (m == this)
-            return this;
-        else if (m instanceof Matrix2f) {
-            MemUtil.INSTANCE.copy((Matrix2f) m, this);
-        } else {
-            setMatrix2fc(m);
+        if (m != this) {
+            MemUtil.INSTANCE.copy(m, this);
         }
         return this;
     }
@@ -274,18 +264,8 @@ public class Matrix2f implements Externalizable, Cloneable, Matrix2fc {
      * @return this
      */
     public Matrix2f set(Matrix3x2fc m) {
-        if (m instanceof Matrix3x2f) {
-            MemUtil.INSTANCE.copy((Matrix3x2f) m, this);
-        } else {
-            setMatrix3x2fc(m);
-        }
+        MemUtil.INSTANCE.copy(m, this);
         return this;
-    }
-    private void setMatrix3x2fc(Matrix3x2fc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
     }
 
     /**
@@ -296,18 +276,8 @@ public class Matrix2f implements Externalizable, Cloneable, Matrix2fc {
      * @return this
      */
     public Matrix2f set(Matrix3fc m) {
-        if (m instanceof Matrix3f) {
-            MemUtil.INSTANCE.copy((Matrix3f) m, this);
-        } else {
-            setMatrix3fc(m);
-        }
+        MemUtil.INSTANCE.copy(m, this);
         return this;
-    }
-    private void setMatrix3fc(Matrix3fc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
     }
 
     /**

--- a/src/main/java/org/joml/Matrix3x2d.java
+++ b/src/main/java/org/joml/Matrix3x2d.java
@@ -68,11 +68,7 @@ public class Matrix3x2d implements Matrix3x2dc, Cloneable, Externalizable {
      *          the {@link Matrix2dc}
      */
     public Matrix3x2d(Matrix2dc mat) {
-        if (mat instanceof Matrix2d) {
-            MemUtil.INSTANCE.copy((Matrix2d) mat, this);
-        } else {
-            setMatrix2dc(mat);
-        }
+        MemUtil.INSTANCE.copy(mat, this);
     }
 
     /**
@@ -96,10 +92,8 @@ public class Matrix3x2d implements Matrix3x2dc, Cloneable, Externalizable {
      *          the {@link Matrix3x2dc} to copy the values from
      */
     public Matrix3x2d(Matrix3x2dc mat) {
-        if (mat instanceof Matrix3x2d) {
-            MemUtil.INSTANCE.copy((Matrix3x2d) mat, this);
-        } else {
-            setMatrix3x2dc(mat);
+        if (mat != this) {
+            MemUtil.INSTANCE.copy(mat, this);
         }
     }
 
@@ -242,22 +236,10 @@ public class Matrix3x2d implements Matrix3x2dc, Cloneable, Externalizable {
      * @return this
      */
     public Matrix3x2d set(Matrix3x2dc m) {
-        if (m == this)
-            return this;
-        else if (m instanceof Matrix3x2d) {
-            MemUtil.INSTANCE.copy((Matrix3x2d) m, this);
-        } else {
-            setMatrix3x2dc(m);
+        if (m != this) {
+            MemUtil.INSTANCE.copy(m, this);
         }
         return this;
-    }
-    private void setMatrix3x2dc(Matrix3x2dc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
-        m20 = mat.m20();
-        m21 = mat.m21();
     }
 
     /**
@@ -268,18 +250,8 @@ public class Matrix3x2d implements Matrix3x2dc, Cloneable, Externalizable {
      * @return this
      */
     public Matrix3x2d set(Matrix2dc m) {
-        if (m instanceof Matrix2d) {
-            MemUtil.INSTANCE.copy((Matrix2d) m, this);
-        } else {
-            setMatrix2dc(m);
-        }
+        MemUtil.INSTANCE.copy(m, this);
         return this;
-    }
-    private void setMatrix2dc(Matrix2dc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
     }
 
     /**

--- a/src/main/java/org/joml/Matrix3x2f.java
+++ b/src/main/java/org/joml/Matrix3x2f.java
@@ -66,10 +66,8 @@ public class Matrix3x2f implements Matrix3x2fc, Externalizable, Cloneable {
      *          the {@link Matrix3x2fc} to copy the values from
      */
     public Matrix3x2f(Matrix3x2fc mat) {
-        if (mat instanceof Matrix3x2f) {
-            MemUtil.INSTANCE.copy((Matrix3x2f) mat, this);
-        } else {
-            setMatrix3x2fc(mat);
+        if (mat != this) {
+            MemUtil.INSTANCE.copy(mat, this);
         }
     }
 
@@ -81,11 +79,7 @@ public class Matrix3x2f implements Matrix3x2fc, Externalizable, Cloneable {
      *          the {@link Matrix2fc}
      */
     public Matrix3x2f(Matrix2fc mat) {
-        if (mat instanceof Matrix2f) {
-            MemUtil.INSTANCE.copy((Matrix2f) mat, this);
-        } else {
-            setMatrix2fc(mat);
-        }
+        MemUtil.INSTANCE.copy(mat, this);
     }
 
     /**
@@ -227,12 +221,8 @@ public class Matrix3x2f implements Matrix3x2fc, Externalizable, Cloneable {
      * @return this
      */
     public Matrix3x2f set(Matrix3x2fc m) {
-        if (m == this)
-            return this;
-        else if (m instanceof Matrix3x2f) {
-            MemUtil.INSTANCE.copy((Matrix3x2f) m, this);
-        } else {
-            setMatrix3x2fc(m);
+        if (m != this) {
+            MemUtil.INSTANCE.copy(m, this);
         }
         return this;
     }
@@ -253,18 +243,8 @@ public class Matrix3x2f implements Matrix3x2fc, Externalizable, Cloneable {
      * @return this
      */
     public Matrix3x2f set(Matrix2fc m) {
-        if (m instanceof Matrix2f) {
-            MemUtil.INSTANCE.copy((Matrix2f) m, this);
-        } else {
-            setMatrix2fc(m);
-        }
+        MemUtil.INSTANCE.copy(m, this);
         return this;
-    }
-    private void setMatrix2fc(Matrix2fc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m10 = mat.m10();
-        m11 = mat.m11();
     }
 
     /**

--- a/src/main/java/org/joml/Matrix4f.java
+++ b/src/main/java/org/joml/Matrix4f.java
@@ -1075,16 +1075,16 @@ public class Matrix4f implements Externalizable, Cloneable, Matrix4fc {
     }
 
     /**
-     * Set the upper left 3x3 submatrix of this {@link Matrix4f} to that of the given {@link Matrix4f} 
+     * Set the upper left 3x3 submatrix of this {@link Matrix4f} to that of the given {@link Matrix4fc}
      * and don't change the other elements.
      * 
      * @param mat
-     *          the {@link Matrix4f}
+     *          the {@link Matrix4fc}
      * @return this
      */
-    public Matrix4f set3x3(Matrix4f mat) {
+    public Matrix4f set3x3(Matrix4fc mat) {
         MemUtil.INSTANCE.copy3x3(mat, this);
-        return _properties(properties & mat.properties & ~(PROPERTY_PERSPECTIVE));
+        return _properties(properties & mat.properties() & ~(PROPERTY_PERSPECTIVE));
     }
 
 
@@ -1116,16 +1116,16 @@ public class Matrix4f implements Externalizable, Cloneable, Matrix4fc {
     }
 
     /**
-     * Set the upper 4x3 submatrix of this {@link Matrix4f} to the upper 4x3 submatrix of the given {@link Matrix4f} 
+     * Set the upper 4x3 submatrix of this {@link Matrix4f} to the upper 4x3 submatrix of the given {@link Matrix4fc}
      * and don't change the other elements.
      * 
      * @param mat
-     *          the {@link Matrix4f}
+     *          the {@link Matrix4fc}
      * @return this
      */
-    public Matrix4f set4x3(Matrix4f mat) {
+    public Matrix4f set4x3(Matrix4fc mat) {
         MemUtil.INSTANCE.copy4x3(mat, this);
-        return _properties(properties & mat.properties & ~(PROPERTY_PERSPECTIVE));
+        return _properties(properties & mat.properties() & ~(PROPERTY_PERSPECTIVE));
     }
 
     /**
@@ -12731,10 +12731,10 @@ public class Matrix4f implements Externalizable, Cloneable, Matrix4fc {
      * <p>
      * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
      * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
-     * In that case, use {@link #set3x3(Matrix4f)} to set a given Matrix4f to only the upper left 3x3 submatrix
+     * In that case, use {@link #set3x3(Matrix4fc)} to set a given Matrix4f to only the upper left 3x3 submatrix
      * of this matrix.
      * 
-     * @see #set3x3(Matrix4f)
+     * @see #set3x3(Matrix4fc)
      * 
      * @return this
      */
@@ -12751,10 +12751,10 @@ public class Matrix4f implements Externalizable, Cloneable, Matrix4fc {
      * <p>
      * Please note that, if <code>this</code> is an orthogonal matrix or a matrix whose columns are orthogonal vectors, 
      * then this method <i>need not</i> be invoked, since in that case <code>this</code> itself is its normal matrix.
-     * In that case, use {@link #set3x3(Matrix4f)} to set a given Matrix4f to only the upper left 3x3 submatrix
+     * In that case, use {@link #set3x3(Matrix4fc)} to set a given Matrix4f to only the upper left 3x3 submatrix
      * of this matrix.
      * 
-     * @see #set3x3(Matrix4f)
+     * @see #set3x3(Matrix4fc)
      * 
      * @param dest
      *             will hold the result

--- a/src/main/java/org/joml/Matrix4x3f.java
+++ b/src/main/java/org/joml/Matrix4x3f.java
@@ -3109,24 +3109,9 @@ public class Matrix4x3f implements Externalizable, Cloneable, Matrix4x3fc {
      * @return this
      */
     public Matrix4x3f set3x3(Matrix3fc mat) {
-        if (mat instanceof Matrix3f) {
-            MemUtil.INSTANCE.copy3x3((Matrix3f) mat, this);
-        } else {
-            set3x3Matrix3fc(mat);
-        }
+        MemUtil.INSTANCE.copy3x3(mat, this);
         properties = PROPERTY_UNKNOWN;
         return this;
-    }
-    private void set3x3Matrix3fc(Matrix3fc mat) {
-        m00 = mat.m00();
-        m01 = mat.m01();
-        m02 = mat.m02();
-        m10 = mat.m10();
-        m11 = mat.m11();
-        m12 = mat.m12();
-        m20 = mat.m20();
-        m21 = mat.m21();
-        m22 = mat.m22();
     }
 
     public Vector4f transform(Vector4f v) {

--- a/src/main/java/org/joml/MemUtil.java
+++ b/src/main/java/org/joml/MemUtil.java
@@ -242,32 +242,32 @@ abstract class MemUtil {
     public abstract Vector4f getColumn(Matrix4f m, int column, Vector4f dest);
     public abstract Matrix4f setColumn(Vector4f v, int column, Matrix4f dest);
     public abstract Matrix4f setColumn(Vector4fc v, int column, Matrix4f dest);
-    public abstract void copy(Matrix4f src, Matrix4f dest);
-    public abstract void copy(Matrix4x3f src, Matrix4x3f dest);
-    public abstract void copy(Matrix4f src, Matrix4x3f dest);
-    public abstract void copy(Matrix4x3f src, Matrix4f dest);
-    public abstract void copy(Matrix3f src, Matrix3f dest);
-    public abstract void copy(Matrix3f src, Matrix4f dest);
-    public abstract void copy(Matrix4f src, Matrix3f dest);
-    public abstract void copy(Matrix3f src, Matrix4x3f dest);
-    public abstract void copy(Matrix3x2f src, Matrix3x2f dest);
-    public abstract void copy(Matrix3x2d src, Matrix3x2d dest);
-    public abstract void copy(Matrix2f src, Matrix2f dest);
-    public abstract void copy(Matrix2d src, Matrix2d dest);
-    public abstract void copy(Matrix2f src, Matrix3f dest);
-    public abstract void copy(Matrix3f src, Matrix2f dest);
-    public abstract void copy(Matrix2f src, Matrix3x2f dest);
-    public abstract void copy(Matrix3x2f src, Matrix2f dest);
-    public abstract void copy(Matrix2d src, Matrix3d dest);
-    public abstract void copy(Matrix3d src, Matrix2d dest);
-    public abstract void copy(Matrix2d src, Matrix3x2d dest);
-    public abstract void copy(Matrix3x2d src, Matrix2d dest);
-    public abstract void copy3x3(Matrix4f src, Matrix4f dest);
-    public abstract void copy3x3(Matrix4x3f src, Matrix4x3f dest);
-    public abstract void copy3x3(Matrix3f src, Matrix4x3f dest);
-    public abstract void copy3x3(Matrix3f src, Matrix4f dest);
-    public abstract void copy4x3(Matrix4f src, Matrix4f dest);
-    public abstract void copy4x3(Matrix4x3f src, Matrix4f dest);
+    public abstract void copy(Matrix4fc src, Matrix4f dest);
+    public abstract void copy(Matrix4x3fc src, Matrix4x3f dest);
+    public abstract void copy(Matrix4fc src, Matrix4x3f dest);
+    public abstract void copy(Matrix4x3fc src, Matrix4f dest);
+    public abstract void copy(Matrix3fc src, Matrix3f dest);
+    public abstract void copy(Matrix3fc src, Matrix4f dest);
+    public abstract void copy(Matrix4fc src, Matrix3f dest);
+    public abstract void copy(Matrix3fc src, Matrix4x3f dest);
+    public abstract void copy(Matrix3x2fc src, Matrix3x2f dest);
+    public abstract void copy(Matrix3x2dc src, Matrix3x2d dest);
+    public abstract void copy(Matrix2fc src, Matrix2f dest);
+    public abstract void copy(Matrix2dc src, Matrix2d dest);
+    public abstract void copy(Matrix2fc src, Matrix3f dest);
+    public abstract void copy(Matrix3fc src, Matrix2f dest);
+    public abstract void copy(Matrix2fc src, Matrix3x2f dest);
+    public abstract void copy(Matrix3x2fc src, Matrix2f dest);
+    public abstract void copy(Matrix2dc src, Matrix3d dest);
+    public abstract void copy(Matrix3dc src, Matrix2d dest);
+    public abstract void copy(Matrix2dc src, Matrix3x2d dest);
+    public abstract void copy(Matrix3x2dc src, Matrix2d dest);
+    public abstract void copy3x3(Matrix4fc src, Matrix4f dest);
+    public abstract void copy3x3(Matrix4x3fc src, Matrix4x3f dest);
+    public abstract void copy3x3(Matrix3fc src, Matrix4x3f dest);
+    public abstract void copy3x3(Matrix3fc src, Matrix4f dest);
+    public abstract void copy4x3(Matrix4fc src, Matrix4f dest);
+    public abstract void copy4x3(Matrix4x3fc src, Matrix4f dest);
     public abstract void copy(float[] arr, int off, Matrix4f dest);
     public abstract void copyTransposed(float[] arr, int off, Matrix4f dest);
     public abstract void copy(float[] arr, int off, Matrix3f dest);
@@ -277,20 +277,20 @@ abstract class MemUtil {
     public abstract void copy(float[] arr, int off, Matrix3x2d dest);
     public abstract void copy(float[] arr, int off, Matrix2f dest);
     public abstract void copy(double[] arr, int off, Matrix2d dest);
-    public abstract void copy(Matrix4f src, float[] dest, int off);
-    public abstract void copy(Matrix3f src, float[] dest, int off);
-    public abstract void copy(Matrix4x3f src, float[] dest, int off);
-    public abstract void copy(Matrix3x2f src, float[] dest, int off);
-    public abstract void copy(Matrix3x2d src, double[] dest, int off);
-    public abstract void copy(Matrix2f src, float[] dest, int off);
-    public abstract void copy(Matrix2d src, double[] dest, int off);
-    public abstract void copy4x4(Matrix4x3f src, float[] dest, int off);
-    public abstract void copy4x4(Matrix4x3d src, float[] dest, int off);
-    public abstract void copy4x4(Matrix4x3d src, double[] dest, int off);
-    public abstract void copy4x4(Matrix3x2f src, float[] dest, int off);
-    public abstract void copy4x4(Matrix3x2d src, double[] dest, int off);
-    public abstract void copy3x3(Matrix3x2f src, float[] dest, int off);
-    public abstract void copy3x3(Matrix3x2d src, double[] dest, int off);
+    public abstract void copy(Matrix4fc src, float[] dest, int off);
+    public abstract void copy(Matrix3fc src, float[] dest, int off);
+    public abstract void copy(Matrix4x3fc src, float[] dest, int off);
+    public abstract void copy(Matrix3x2fc src, float[] dest, int off);
+    public abstract void copy(Matrix3x2dc src, double[] dest, int off);
+    public abstract void copy(Matrix2fc src, float[] dest, int off);
+    public abstract void copy(Matrix2dc src, double[] dest, int off);
+    public abstract void copy4x4(Matrix4x3fc src, float[] dest, int off);
+    public abstract void copy4x4(Matrix4x3dc src, float[] dest, int off);
+    public abstract void copy4x4(Matrix4x3dc src, double[] dest, int off);
+    public abstract void copy4x4(Matrix3x2fc src, float[] dest, int off);
+    public abstract void copy4x4(Matrix3x2dc src, double[] dest, int off);
+    public abstract void copy3x3(Matrix3x2fc src, float[] dest, int off);
+    public abstract void copy3x3(Matrix3x2dc src, double[] dest, int off);
     public abstract void identity(Matrix4f dest);
     public abstract void identity(Matrix4x3f dest);
     public abstract void identity(Matrix3f dest);
@@ -2936,7 +2936,7 @@ abstract class MemUtil {
             }
         }
 
-        public void copy(Matrix4f src, Matrix4f dest) {
+        public void copy(Matrix4fc src, Matrix4f dest) {
             dest._m00(src.m00()).
             _m01(src.m01()).
             _m02(src.m02()).
@@ -2955,7 +2955,7 @@ abstract class MemUtil {
             _m33(src.m33());
         }
 
-        public void copy(Matrix3f src, Matrix4f dest) {
+        public void copy(Matrix3fc src, Matrix4f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -2974,7 +2974,7 @@ abstract class MemUtil {
             ._m33(1.0f);
         }
 
-        public void copy(Matrix4f src, Matrix3f dest) {
+        public void copy(Matrix4fc src, Matrix3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -2986,7 +2986,7 @@ abstract class MemUtil {
             ._m22(src.m22());
         }
 
-        public void copy(Matrix3f src, Matrix4x3f dest) {
+        public void copy(Matrix3fc src, Matrix4x3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3001,7 +3001,7 @@ abstract class MemUtil {
             ._m32(0.0f);
         }
 
-        public void copy(Matrix3x2f src, Matrix3x2f dest) {
+        public void copy(Matrix3x2fc src, Matrix3x2f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
@@ -3010,7 +3010,7 @@ abstract class MemUtil {
             ._m21(src.m21());
         }
 
-        public void copy(Matrix3x2d src, Matrix3x2d dest) {
+        public void copy(Matrix3x2dc src, Matrix3x2d dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
@@ -3019,21 +3019,21 @@ abstract class MemUtil {
             ._m21(src.m21());
         }
 
-        public void copy(Matrix2f src, Matrix2f dest) {
+        public void copy(Matrix2fc src, Matrix2f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
             ._m11(src.m11());
         }
 
-        public void copy(Matrix2d src, Matrix2d dest) {
+        public void copy(Matrix2dc src, Matrix2d dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
             ._m11(src.m11());
         }
 
-        public void copy(Matrix2f src, Matrix3f dest) {
+        public void copy(Matrix2fc src, Matrix3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(0.0f)
@@ -3045,14 +3045,14 @@ abstract class MemUtil {
             ._m22(1.0f);
         }
 
-        public void copy(Matrix3f src, Matrix2f dest) {
+        public void copy(Matrix3fc src, Matrix2f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
             ._m11(src.m11());
         }
 
-        public void copy(Matrix2f src, Matrix3x2f dest) {
+        public void copy(Matrix2fc src, Matrix3x2f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
@@ -3061,14 +3061,14 @@ abstract class MemUtil {
             ._m21(0.0f);
         }
 
-        public void copy(Matrix3x2f src, Matrix2f dest) {
+        public void copy(Matrix3x2fc src, Matrix2f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
             ._m11(src.m11());
         }
 
-        public void copy(Matrix2d src, Matrix3d dest) {
+        public void copy(Matrix2dc src, Matrix3d dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(0.0)
@@ -3080,14 +3080,14 @@ abstract class MemUtil {
             ._m22(1.0);
         }
 
-        public void copy(Matrix3d src, Matrix2d dest) {
+        public void copy(Matrix3dc src, Matrix2d dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
             ._m11(src.m11());
         }
 
-        public void copy(Matrix2d src, Matrix3x2d dest) {
+        public void copy(Matrix2dc src, Matrix3x2d dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
@@ -3096,14 +3096,14 @@ abstract class MemUtil {
             ._m21(0.0);
         }
 
-        public void copy(Matrix3x2d src, Matrix2d dest) {
+        public void copy(Matrix3x2dc src, Matrix2d dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m10(src.m10())
             ._m11(src.m11());
         }
 
-        public void copy3x3(Matrix4f src, Matrix4f dest) {
+        public void copy3x3(Matrix4fc src, Matrix4f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3115,7 +3115,7 @@ abstract class MemUtil {
             ._m22(src.m22());
         }
 
-        public void copy3x3(Matrix4x3f src, Matrix4x3f dest) {
+        public void copy3x3(Matrix4x3fc src, Matrix4x3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3127,7 +3127,7 @@ abstract class MemUtil {
             ._m22(src.m22());
         }
 
-        public void copy3x3(Matrix3f src, Matrix4x3f dest) {
+        public void copy3x3(Matrix3fc src, Matrix4x3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3139,7 +3139,7 @@ abstract class MemUtil {
             ._m22(src.m22());
         }
 
-        public void copy3x3(Matrix3f src, Matrix4f dest) {
+        public void copy3x3(Matrix3fc src, Matrix4f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3151,7 +3151,7 @@ abstract class MemUtil {
             ._m22(src.m22());
         }
 
-        public void copy4x3(Matrix4x3f src, Matrix4f dest) {
+        public void copy4x3(Matrix4x3fc src, Matrix4f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3166,7 +3166,7 @@ abstract class MemUtil {
             ._m32(src.m32());
         }
 
-        public void copy4x3(Matrix4f src, Matrix4f dest) {
+        public void copy4x3(Matrix4fc src, Matrix4f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3181,7 +3181,7 @@ abstract class MemUtil {
             ._m32(src.m32());
         }
 
-        public void copy(Matrix4f src, Matrix4x3f dest) {
+        public void copy(Matrix4fc src, Matrix4x3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3196,7 +3196,7 @@ abstract class MemUtil {
             ._m32(src.m32());
         }
 
-        public void copy(Matrix4x3f src, Matrix4f dest) {
+        public void copy(Matrix4x3fc src, Matrix4f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3215,7 +3215,7 @@ abstract class MemUtil {
             ._m33(1.0f);
         }
 
-        public void copy(Matrix4x3f src, Matrix4x3f dest) {
+        public void copy(Matrix4x3fc src, Matrix4x3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3230,7 +3230,7 @@ abstract class MemUtil {
             ._m32(src.m32());
         }
 
-        public void copy(Matrix3f src, Matrix3f dest) {
+        public void copy(Matrix3fc src, Matrix3f dest) {
             dest._m00(src.m00())
             ._m01(src.m01())
             ._m02(src.m02())
@@ -3348,7 +3348,7 @@ abstract class MemUtil {
             ._m11(arr[off+3]);
         }
 
-        public void copy(Matrix4f src, float[] dest, int off) {
+        public void copy(Matrix4fc src, float[] dest, int off) {
             dest[off+0]  = src.m00();
             dest[off+1]  = src.m01();
             dest[off+2]  = src.m02();
@@ -3367,7 +3367,7 @@ abstract class MemUtil {
             dest[off+15] = src.m33();
         }
 
-        public void copy(Matrix3f src, float[] dest, int off) {
+        public void copy(Matrix3fc src, float[] dest, int off) {
             dest[off+0] = src.m00();
             dest[off+1] = src.m01();
             dest[off+2] = src.m02();
@@ -3379,7 +3379,7 @@ abstract class MemUtil {
             dest[off+8] = src.m22();
         }
 
-        public void copy(Matrix4x3f src, float[] dest, int off) {
+        public void copy(Matrix4x3fc src, float[] dest, int off) {
             dest[off+0]  = src.m00();
             dest[off+1]  = src.m01();
             dest[off+2]  = src.m02();
@@ -3394,7 +3394,7 @@ abstract class MemUtil {
             dest[off+11] = src.m32();
         }
 
-        public void copy(Matrix3x2f src, float[] dest, int off) {
+        public void copy(Matrix3x2fc src, float[] dest, int off) {
             dest[off+0] = src.m00();
             dest[off+1] = src.m01();
             dest[off+2] = src.m10();
@@ -3403,7 +3403,7 @@ abstract class MemUtil {
             dest[off+5] = src.m21();
         }
 
-        public void copy(Matrix3x2d src, double[] dest, int off) {
+        public void copy(Matrix3x2dc src, double[] dest, int off) {
             dest[off+0] = src.m00();
             dest[off+1] = src.m01();
             dest[off+2] = src.m10();
@@ -3412,21 +3412,21 @@ abstract class MemUtil {
             dest[off+5] = src.m21();
         }
 
-        public void copy(Matrix2f src, float[] dest, int off) {
+        public void copy(Matrix2fc src, float[] dest, int off) {
             dest[off+0] = src.m00();
             dest[off+1] = src.m01();
             dest[off+2] = src.m10();
             dest[off+3] = src.m11();
         }
 
-        public void copy(Matrix2d src, double[] dest, int off) {
+        public void copy(Matrix2dc src, double[] dest, int off) {
             dest[off+0] = src.m00();
             dest[off+1] = src.m01();
             dest[off+2] = src.m10();
             dest[off+3] = src.m11();
         }
 
-        public void copy4x4(Matrix4x3f src, float[] dest, int off) {
+        public void copy4x4(Matrix4x3fc src, float[] dest, int off) {
             dest[off+0]  = src.m00();
             dest[off+1]  = src.m01();
             dest[off+2]  = src.m02();
@@ -3445,7 +3445,7 @@ abstract class MemUtil {
             dest[off+15] = 1.0f;
         }
 
-        public void copy4x4(Matrix4x3d src, float[] dest, int off) {
+        public void copy4x4(Matrix4x3dc src, float[] dest, int off) {
             dest[off+0]  = (float) src.m00();
             dest[off+1]  = (float) src.m01();
             dest[off+2]  = (float) src.m02();
@@ -3464,7 +3464,7 @@ abstract class MemUtil {
             dest[off+15] = 1.0f;
         }
 
-        public void copy4x4(Matrix4x3d src, double[] dest, int off) {
+        public void copy4x4(Matrix4x3dc src, double[] dest, int off) {
             dest[off+0]  = src.m00();
             dest[off+1]  = src.m01();
             dest[off+2]  = src.m02();
@@ -3483,7 +3483,7 @@ abstract class MemUtil {
             dest[off+15] = 1.0;
         }
 
-        public void copy3x3(Matrix3x2f src, float[] dest, int off) {
+        public void copy3x3(Matrix3x2fc src, float[] dest, int off) {
             dest[off+0] = src.m00();
             dest[off+1] = src.m01();
             dest[off+2] = 0.0f;
@@ -3495,7 +3495,7 @@ abstract class MemUtil {
             dest[off+8] = 1.0f;
         }
 
-        public void copy3x3(Matrix3x2d src, double[] dest, int off) {
+        public void copy3x3(Matrix3x2dc src, double[] dest, int off) {
             dest[off+0] = src.m00();
             dest[off+1] = src.m01();
             dest[off+2] = 0.0;
@@ -3507,7 +3507,7 @@ abstract class MemUtil {
             dest[off+8] = 1.0;
         }
 
-        public void copy4x4(Matrix3x2f src, float[] dest, int off) {
+        public void copy4x4(Matrix3x2fc src, float[] dest, int off) {
             dest[off+0]  = src.m00();
             dest[off+1]  = src.m01();
             dest[off+2]  = 0.0f;
@@ -3526,7 +3526,7 @@ abstract class MemUtil {
             dest[off+15] = 1.0f;
         }
 
-        public void copy4x4(Matrix3x2d src, double[] dest, int off) {
+        public void copy4x4(Matrix3x2dc src, double[] dest, int off) {
             dest[off+0]  = src.m00();
             dest[off+1]  = src.m01();
             dest[off+2]  = 0.0;


### PR DESCRIPTION
All of the underlying `MemUtil` functions for copying rely on the read-only interface methods. These now specify the read-only class in their parameters. This should allow for greater flexibility in using these memory helpers.